### PR TITLE
Implement basic pod and menu UI

### DIFF
--- a/nixos/example/CMakeLists.txt
+++ b/nixos/example/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.20)
+project(etheros-example)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
+add_executable(etheros-example main.cpp)
+target_link_libraries(etheros-example PRIVATE Qt6::Widgets)

--- a/nixos/example/main.cpp
+++ b/nixos/example/main.cpp
@@ -1,0 +1,9 @@
+#include <QApplication>
+#include <QPushButton>
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+    QPushButton btn("Hello EtherOS");
+    btn.show();
+    return app.exec();
+}

--- a/nixos/shell.nix
+++ b/nixos/shell.nix
@@ -1,5 +1,13 @@
 { pkgs ? import <nixpkgs> {} }:
 
 pkgs.mkShell {
-  buildInputs = [ pkgs.nixos-rebuild pkgs.git ];
+  buildInputs = [
+    pkgs.nixos-rebuild
+    pkgs.git
+    pkgs.cmake
+    pkgs.pkg-config
+    pkgs.qt6.qtbase
+    pkgs.qt6.qtdeclarative
+    pkgs.qt6.qtwayland
+  ];
 }

--- a/shared/environments.json
+++ b/shared/environments.json
@@ -1,0 +1,5 @@
+[
+  { "id": "rainforest", "name": "Rainforest", "background": "forest.jpg" },
+  { "id": "36chambers", "name": "36 Chambers", "background": "chamber.jpg" },
+  { "id": "island", "name": "Island", "background": "island.jpg" }
+]

--- a/web/public/environments.json
+++ b/web/public/environments.json
@@ -1,0 +1,5 @@
+[
+  { "id": "rainforest", "name": "Rainforest", "background": "forest.jpg" },
+  { "id": "36chambers", "name": "36 Chambers", "background": "chamber.jpg" },
+  { "id": "island", "name": "Island", "background": "island.jpg" }
+]

--- a/web/src/components/EnvManager.tsx
+++ b/web/src/components/EnvManager.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+
+interface Environment {
+  id: string;
+  name: string;
+  background: string;
+}
+
+const ENV_KEY = 'etheros.currentEnv';
+
+export default function EnvManager() {
+  const [envs, setEnvs] = useState<Environment[]>([]);
+  const [current, setCurrent] = useState<string>(() =>
+    localStorage.getItem(ENV_KEY) || ''
+  );
+
+  useEffect(() => {
+    fetch('/environments.json')
+      .then((res) => res.json())
+      .then((data) => setEnvs(data));
+  }, []);
+
+  const switchEnv = (id: string, bg: string) => {
+    setCurrent(id);
+    localStorage.setItem(ENV_KEY, id);
+    document.body.style.backgroundImage = `url(${bg})`;
+    document.body.style.backgroundSize = 'cover';
+  };
+
+  return (
+    <div className="absolute top-4 left-4 bg-white bg-opacity-80 p-2 rounded shadow">
+      <h2 className="font-bold mb-1">Environments</h2>
+      <ul className="flex gap-2">
+        {envs.map((env) => (
+          <li key={env.id}>
+            <button
+              className={`px-2 py-1 rounded ${
+                current === env.id ? 'bg-blue-500 text-white' : 'bg-gray-200'
+              }`}
+              onClick={() => switchEnv(env.id, env.background)}
+            >
+              {env.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/LauncherMenu.tsx
+++ b/web/src/components/LauncherMenu.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+
+const apps = [
+  { name: 'Terminal', action: () => alert('Terminal launching...') },
+  { name: 'Settings', action: () => alert('Settings opening...') },
+  { name: 'Docs', action: () => window.open('https://example.com', '_blank') },
+];
+
+export default function LauncherMenu() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="absolute bottom-4 left-4">
+      <button
+        className="bg-gray-800 text-white px-3 py-2 rounded"
+        onClick={() => setOpen(!open)}
+      >
+        Start
+      </button>
+      {open && (
+        <div className="mt-1 p-2 bg-white shadow-lg rounded w-40">
+          <input
+            placeholder="Search..."
+            className="w-full mb-2 border px-1 py-0.5"
+          />
+          <ul className="space-y-1">
+            {apps.map((app) => (
+              <li key={app.name}>
+                <button
+                  onClick={app.action}
+                  className="w-full text-left px-1 py-0.5 hover:bg-gray-100"
+                >
+                  {app.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
+import EnvManager from './components/EnvManager';
+import LauncherMenu from './components/LauncherMenu';
 
 function Landscape() {
   const geom = useMemo(() => {
@@ -67,9 +69,13 @@ function Scene() {
 }
 
 const App = () => (
-  <Canvas className="w-screen h-screen bg-black">
-    <Scene />
-  </Canvas>
+  <div className="w-screen h-screen relative overflow-hidden">
+    <Canvas className="w-full h-full bg-black">
+      <Scene />
+    </Canvas>
+    <EnvManager />
+    <LauncherMenu />
+  </div>
 );
 
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## Summary
- add initial environment listing JSON
- create EnvManager UI for switching pods
- add simple LauncherMenu component
- wire new components into index
- provide Qt6 dev shell with example app

## Testing
- `npm run build` *(fails: vite not found)*
- `nix develop` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684414c88a70832f95e5ce4a7a9061d1