### PR TITLE
Add developer-friendly logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
-    "test": "vitest run -w web && vitest run -w runtime"
+    "test": "vitest run --config web/vitest.config.ts && vitest run runtime"
   },
   "devDependencies": {
     "eslint": "^8.56.0",

--- a/runtime/src/commands.ts
+++ b/runtime/src/commands.ts
@@ -5,14 +5,18 @@ export type Command = {
 
 export type CommandHandler = (cmd: Command) => void;
 
+import { info } from './logger';
+
 const handlers: Record<string, CommandHandler[]> = {};
 
 export function register(type: string, handler: CommandHandler) {
   if (!handlers[type]) handlers[type] = [];
   handlers[type].push(handler);
+  info(`Registered handler for command: ${type}`);
 }
 
 export function dispatch(cmd: Command) {
+  info(`Dispatching command: ${cmd.type}`, cmd.payload);
   (handlers[cmd.type] || []).forEach((h) => h(cmd));
 }
 

--- a/runtime/src/gestures.ts
+++ b/runtime/src/gestures.ts
@@ -1,7 +1,10 @@
 // TODO: integrate real gesture recognition logic
 export type Gesture = 'swipe-left' | 'swipe-right' | 'tap';
 
+import { info } from './logger';
+
 export function handleGesture(g: Gesture): string {
+  info(`Handling gesture: ${g}`);
   // simple routing logic for now
   switch (g) {
     case 'swipe-left':

--- a/runtime/src/logger.ts
+++ b/runtime/src/logger.ts
@@ -1,0 +1,14 @@
+export function log(level: string, message: string, meta?: unknown) {
+  const time = new Date().toISOString();
+  if (meta !== undefined) {
+    // eslint-disable-next-line no-console
+    console.log(`[${time}] [${level}] ${message}`, meta);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`[${time}] [${level}] ${message}`);
+  }
+}
+
+export const info = (message: string, meta?: unknown) => log('INFO', message, meta);
+export const warn = (message: string, meta?: unknown) => log('WARN', message, meta);
+export const error = (message: string, meta?: unknown) => log('ERROR', message, meta);

--- a/runtime/src/state.ts
+++ b/runtime/src/state.ts
@@ -1,4 +1,6 @@
 // simple in-memory state store
+import { info } from './logger';
+
 export interface State {
   currentEnv: string;
 }
@@ -7,9 +9,11 @@ let state: State = { currentEnv: '' };
 
 export function setState(partial: Partial<State>) {
   state = { ...state, ...partial };
+  info('State updated', partial);
 }
 
 export function getState(): State {
+  info('State retrieved', state);
   return state;
 }
 

--- a/web/src/components/EnvManager.tsx
+++ b/web/src/components/EnvManager.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { info, error } from '../logger';
 
 interface Environment {
   id: string;
@@ -15,9 +16,14 @@ export default function EnvManager() {
   );
 
   useEffect(() => {
+    info('Fetching environments');
     fetch('/environments.json')
       .then((res) => res.json())
-      .then((data) => setEnvs(data));
+      .then((data) => {
+        info('Loaded environments', data);
+        setEnvs(data);
+      })
+      .catch((err) => error('Failed to load environments', err));
   }, []);
 
   const switchEnv = (id: string, bg: string) => {
@@ -25,6 +31,7 @@ export default function EnvManager() {
     localStorage.setItem(ENV_KEY, id);
     document.body.style.backgroundImage = `url(${bg})`;
     document.body.style.backgroundSize = 'cover';
+    info(`Switched environment to ${id}`);
   };
 
   return (

--- a/web/src/components/LauncherMenu.tsx
+++ b/web/src/components/LauncherMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { info } from '../logger';
 
 const apps = [
   { name: 'Terminal', action: () => alert('Terminal launching...') },
@@ -13,7 +14,10 @@ export default function LauncherMenu() {
     <div className="absolute bottom-4 left-4">
       <button
         className="bg-gray-800 text-white px-3 py-2 rounded"
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          setOpen(!open);
+          info(`Launcher menu ${!open ? 'opened' : 'closed'}`);
+        }}
       >
         Start
       </button>
@@ -27,7 +31,10 @@ export default function LauncherMenu() {
             {apps.map((app) => (
               <li key={app.name}>
                 <button
-                  onClick={app.action}
+                  onClick={() => {
+                    info(`Launching ${app.name}`);
+                    app.action();
+                  }}
                   className="w-full text-left px-1 py-0.5 hover:bg-gray-100"
                 >
                   {app.name}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useMemo, useEffect, useState } from 'react';
+import { info } from './logger';
 import ReactDOM from 'react-dom/client';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
@@ -78,4 +79,5 @@ const App = () => (
   </div>
 );
 
+info('Starting web application');
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/web/src/logger.ts
+++ b/web/src/logger.ts
@@ -1,0 +1,14 @@
+export function log(level: string, message: string, meta?: unknown) {
+  const time = new Date().toISOString();
+  if (meta !== undefined) {
+    // eslint-disable-next-line no-console
+    console.log(`[${time}] [${level}] ${message}`, meta);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`[${time}] [${level}] ${message}`);
+  }
+}
+
+export const info = (message: string, meta?: unknown) => log('INFO', message, meta);
+export const warn = (message: string, meta?: unknown) => log('WARN', message, meta);
+export const error = (message: string, meta?: unknown) => log('ERROR', message, meta);


### PR DESCRIPTION
## Summary
- add logger modules for runtime and web packages
- emit logs when gestures, commands, state updates, and UI events occur
- ensure web tests run with explicit config so they pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846d24e5088832f8400e1ad620c40dc