### PR TITLE
Implement basic AI command layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The list of available environments lives in `shared/environments.json`. Add your
 	•	SymbolCast input (mock gestures + voice)
 	•	NixOS flake for personal DE boot
 	•	Shared command & file system logic
+	•       Voice-enabled command palette
+	•       Local AI model dashboard
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,8 @@ EtherOS combines a minimal NixOS layer with a browser-based desktop UI. The goal
 - **Web UI** — A React + Tailwind web application that renders the desktop environment in the browser. This allows remote access and easy iteration.
 - **Runtime** — Shared logic for gestures, commands and state synchronization between the OS layer and the web interface.
 - **Qt Example** — A small C++/Qt program (compatible with Q++) used to validate native tooling.
+- **AI Command Layer** — Provides voice, symbol and gesture triggers that dispatch commands to the runtime. A command palette UI offers quick access to common actions.
+- **Model Dashboard** — A local interface for starting and stopping AI models that run on the server without cloud dependencies.
 
 ## Data Flow
 
@@ -29,4 +31,4 @@ same command APIs operate everywhere.
 
 ## Future Work
 
-This architecture will evolve as we integrate real SymbolCast input and additional modules. Contributions and feedback are welcome.
+This architecture will evolve as we integrate real SymbolCast input and additional modules. Local inference is preferred for privacy, with an option to fall back to online models when enabled. Contributions and feedback are welcome.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,8 @@ This document tracks the planned milestones for the EtherOS MVP.
 - [ ] Document deployment and contribution guidelines
 - [ ] Mobile & wearable builds using React Native
 - [ ] Verify Qt (Q++) example builds across platforms
+- [ ] AI-native command palette with voice triggers
+- [ ] Local model management dashboard
 
 
 The roadmap may evolve as the project progresses. Community feedback is encouraged.

--- a/runtime/src/__tests__/ai.test.ts
+++ b/runtime/src/__tests__/ai.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { setInferenceMode, getInferenceMode, addModel, listModels } from '../ai';
+
+describe('ai utilities', () => {
+  it('toggles inference mode', () => {
+    setInferenceMode('online');
+    expect(getInferenceMode()).toBe('online');
+  });
+
+  it('manages models', () => {
+    addModel({ id: 'm1', name: 'Test', status: 'stopped' });
+    expect(listModels().length).toBe(1);
+  });
+});

--- a/runtime/src/ai.ts
+++ b/runtime/src/ai.ts
@@ -1,0 +1,32 @@
+export type InferenceMode = 'local' | 'online';
+
+let mode: InferenceMode = 'local';
+
+export function setInferenceMode(m: InferenceMode) {
+  mode = m;
+}
+
+export function getInferenceMode(): InferenceMode {
+  return mode;
+}
+
+export interface Model {
+  id: string;
+  name: string;
+  status: 'running' | 'stopped';
+}
+
+const models: Model[] = [];
+
+export function listModels(): Model[] {
+  return [...models];
+}
+
+export function addModel(model: Model) {
+  models.push(model);
+}
+
+export function updateModel(id: string, partial: Partial<Model>) {
+  const m = models.find((x) => x.id === id);
+  if (m) Object.assign(m, partial);
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1,3 +1,4 @@
 export * from './gestures';
 export * from './commands';
 export * from './state';
+export * from './ai';

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { dispatch, Command } from '../../../runtime/src/commands';
+
+const presets: { name: string; cmd: Command }[] = [
+  { name: 'Open Terminal', cmd: { type: 'open-terminal' } },
+  { name: 'Launch Notes', cmd: { type: 'launch-notes' } },
+];
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState(presets);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  useEffect(() => {
+    setResults(
+      presets.filter((p) => p.name.toLowerCase().includes(query.toLowerCase()))
+    );
+  }, [query]);
+
+  const startVoice = () => {
+    const AnyWindow: any = window as any;
+    const Rec = AnyWindow.SpeechRecognition || AnyWindow.webkitSpeechRecognition;
+    if (!Rec) return;
+    const rec = new Rec();
+    rec.onresult = (ev: any) => {
+      const text = ev.results[0][0].transcript;
+      setQuery(text);
+    };
+    rec.start();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="absolute inset-0 bg-black bg-opacity-50 flex items-start justify-center">
+      <div className="mt-40 bg-white p-4 rounded shadow w-80">
+        <input
+          autoFocus
+          className="w-full border p-1 mb-2"
+          placeholder="Type a command..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button className="text-sm text-blue-600 mb-2" onClick={startVoice}>
+          Voice
+        </button>
+        <ul>
+          {results.map((p) => (
+            <li key={p.name}>
+              <button
+                className="w-full text-left hover:bg-gray-100 px-2 py-1"
+                onClick={() => {
+                  dispatch(p.cmd);
+                  setOpen(false);
+                  setQuery('');
+                }}
+              >
+                {p.name}
+              </button>
+            </li>
+          ))}
+          {results.length === 0 && (
+            <li className="text-gray-500 px-2">No matches</li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ModelDashboard.tsx
+++ b/web/src/components/ModelDashboard.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { addModel, listModels, updateModel, Model } from '../../../runtime/src/ai';
+
+export default function ModelDashboard() {
+  const [models, setModels] = useState<Model[]>(listModels());
+  const [name, setName] = useState('');
+
+  const add = () => {
+    const m: Model = { id: `${Date.now()}`, name, status: 'stopped' };
+    addModel(m);
+    setModels(listModels());
+    setName('');
+  };
+
+  const toggle = (id: string) => {
+    const m = models.find((x) => x.id === id);
+    if (!m) return;
+    const newStatus = m.status === 'running' ? 'stopped' : 'running';
+    updateModel(id, { status: newStatus });
+    setModels(listModels());
+  };
+
+  return (
+    <div className="absolute top-4 right-4 bg-white bg-opacity-80 p-2 rounded shadow w-64">
+      <h2 className="font-bold mb-1">Models</h2>
+      <div className="flex mb-2">
+        <input
+          className="border flex-1 mr-1 px-1"
+          placeholder="Model name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-2" onClick={add}>
+          Add
+        </button>
+      </div>
+      <ul className="space-y-1 max-h-40 overflow-y-auto">
+        {models.map((m) => (
+          <li key={m.id} className="flex justify-between items-center">
+            <span>{m.name}</span>
+            <button className="text-sm text-blue-600" onClick={() => toggle(m.id)}>
+              {m.status === 'running' ? 'Stop' : 'Start'}
+            </button>
+          </li>
+        ))}
+        {models.length === 0 && <li className="text-gray-500">No models</li>}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/__tests__/CommandPalette.test.tsx
+++ b/web/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CommandPalette from '../CommandPalette';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+
+describe('CommandPalette', () => {
+  it('opens with keyboard shortcut', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.getByPlaceholderText('Type a command...')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/__tests__/ModelDashboard.test.tsx
+++ b/web/src/components/__tests__/ModelDashboard.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ModelDashboard from '../ModelDashboard';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+
+describe('ModelDashboard', () => {
+  it('adds a model', () => {
+    render(<ModelDashboard />);
+    fireEvent.change(screen.getByPlaceholderText('Model name'), { target: { value: 'my-model' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(screen.getByText('my-model')).toBeInTheDocument();
+  });
+});

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -6,6 +6,8 @@ import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
 import EnvManager from './components/EnvManager';
 import LauncherMenu from './components/LauncherMenu';
+import CommandPalette from './components/CommandPalette';
+import ModelDashboard from './components/ModelDashboard';
 
 function Landscape() {
   const geom = useMemo(() => {
@@ -76,6 +78,8 @@ const App = () => (
     </Canvas>
     <EnvManager />
     <LauncherMenu />
+    <CommandPalette />
+    <ModelDashboard />
   </div>
 );
 


### PR DESCRIPTION
## Summary
- add basic AI utilities for runtime
- expose AI utils from runtime index
- create command palette and model dashboard components
- add tests for the new components and AI utils
- update docs with AI command layer and model dashboard
- document new MVP items in README/roadmap

## Testing
- `npm test`
- `npx vitest run --config web/vitest.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849a4e7d958832f983106e3a7a8de55