### PR TITLE
Add Q++ environment view manager

### DIFF
--- a/runtime/quantum/environment_view_manager.cpp
+++ b/runtime/quantum/environment_view_manager.cpp
@@ -1,0 +1,116 @@
+#include <qpp/qpp.h>
+#include <iostream>
+#include <vector>
+#include <string>
+
+// EnvironmentViewManager simulates foreground, middle ground and background
+// layers when no quantum hardware is available.  The class uses the
+// Quantum++ library to collapse a superposition state on double tap, selecting
+// which layer becomes active.
+
+namespace eco {
+
+struct Point {
+    double x;
+    double y;
+};
+
+class EnvironmentViewManager {
+  public:
+    enum class Layer { Foreground = 0, MiddleGround = 1, Background = 2 };
+
+    EnvironmentViewManager();
+
+    // Simulate the double tap gesture. A quantum measurement is used to
+    // determine the target layer if hardware QPU is not present.
+    void handleDoubleTap();
+
+    // Foreground helpers ----------------------------------------------------
+    // Draw freeform symbols on the foreground using trackpad input.
+    void drawSymbol(const std::vector<Point>& stroke);
+
+    // Middle ground helpers -------------------------------------------------
+    // Display a standard application window, e.g. a browser tab.
+    void openApplication(const std::string& appName);
+
+    // Background helpers ----------------------------------------------------
+    // Visit a procedurally generated VR "pod" world.
+    void visitBackgroundWorld(const std::string& podId);
+
+  private:
+    Layer activeLayer;
+
+    void activateLayer(Layer layer);
+};
+
+EnvironmentViewManager::EnvironmentViewManager()
+    : activeLayer(Layer::MiddleGround) {}
+
+void EnvironmentViewManager::handleDoubleTap() {
+    using namespace qpp; // use Quantum++ primitives
+
+    // Use two qubits in superposition to pick one of three layers
+    ket q1 = 0_ket, q2 = 0_ket;
+    q1 = gt.H * q1;
+    q2 = gt.H * q2;
+    auto r1 = measure(q1, 0);
+    auto r2 = measure(q2, 0);
+    int outcome = std::get<RESULT>(r1) * 2 + std::get<RESULT>(r2);
+
+    Layer target = static_cast<Layer>(outcome % 3);
+    activateLayer(target);
+}
+
+void EnvironmentViewManager::activateLayer(Layer layer) {
+    activeLayer = layer;
+    switch (layer) {
+    case Layer::Foreground:
+        std::cout << "Entered Foreground: draw with trackpad" << std::endl;
+        break;
+    case Layer::MiddleGround:
+        std::cout << "Entered Middle Ground: application windows" << std::endl;
+        break;
+    case Layer::Background:
+        std::cout << "Entered Background: VR world" << std::endl;
+        break;
+    }
+}
+
+void EnvironmentViewManager::drawSymbol(const std::vector<Point>& stroke) {
+    if (activeLayer != Layer::Foreground) {
+        std::cout << "Not in foreground" << std::endl;
+        return;
+    }
+    std::cout << "Drawing symbol with " << stroke.size() << " points" << std::endl;
+}
+
+void EnvironmentViewManager::openApplication(const std::string& appName) {
+    if (activeLayer != Layer::MiddleGround) {
+        std::cout << "Not in middle ground" << std::endl;
+        return;
+    }
+    std::cout << "Opening application: " << appName << std::endl;
+}
+
+void EnvironmentViewManager::visitBackgroundWorld(const std::string& podId) {
+    if (activeLayer != Layer::Background) {
+        std::cout << "Not in background" << std::endl;
+        return;
+    }
+    std::cout << "Visiting background pod: " << podId << std::endl;
+}
+
+} // namespace eco
+
+int main() {
+    eco::EnvironmentViewManager manager;
+    // Example usage
+    manager.handleDoubleTap();
+    manager.drawSymbol({{0, 0}, {1, 1}});
+    manager.handleDoubleTap();
+    manager.openApplication("Chrome");
+    manager.handleDoubleTap();
+    manager.visitBackgroundWorld("public-square");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add `EnvironmentViewManager` in Q++ to simulate foreground, middle ground, and background layers
- handle double tap via Quantum++ measurements to select active layer
- stub methods for drawing, opening applications, and visiting VR pods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c232646c832f972aa96d7e5107f0