### PR TITLE
docs: add package READMEs

### DIFF
--- a/nixos/README.md
+++ b/nixos/README.md
@@ -1,0 +1,28 @@
+# NixOS Layer
+
+This directory contains the NixOS configuration for EtherOS.
+
+## Structure
+- `flake.nix` – flake entry point with overlays and packages
+- `desktop.nix` – desktop environment modules
+- `server.nix` – server configuration for remote sessions
+- `module.nix` – reusable module definitions
+- `shell.nix` – development shell for building examples
+- `example/` – small Qt demo used to test native builds
+
+## Usage
+```bash
+cd nixos
+nix develop
+nixos-rebuild switch --flake .
+```
+
+To build the Qt example:
+```bash
+cd nixos
+nix develop
+cd example
+cmake -B build
+cmake --build build
+./build/etheros-example
+```

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,17 @@
+# Runtime Library
+
+The runtime package provides shared logic for SymbolCast input, state
+management, and command handling.
+
+## Structure
+- `src/` – TypeScript sources
+- `quantum/` – quantum framework wrappers
+- `dist/` – compiled output
+- `package.json` – build scripts and dependencies
+
+## Building
+From repository root:
+```bash
+npm run build -w runtime
+```
+The build outputs to `runtime/dist`.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,18 @@
+# Web Interface
+
+The `web` directory contains the browser-based EtherOS interface built with
+React, Vite, and Tailwind CSS.
+
+## Development
+```bash
+cd web
+npm install
+npm run dev
+```
+This starts the development server at `localhost:5173`.
+
+## Testing
+```bash
+npm test
+```
+Uses Vitest for unit tests.


### PR DESCRIPTION
## Summary
- add NixOS layer README with build instructions
- document runtime package structure and build
- add web interface README with development and testing steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68955babce58832fa25c857757c03e12