### PR TITLE
refactor: move Qt demo to networked desktop example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 EtherOS is a next-gen modular desktop environment built for immersive computing, symbolic input, and decentralized session portability.
 
 This repo contains:
-- A **NixOS-based desktop environment layer**
+- A **cross-platform desktop environment layer**
 - A **browser-accessible web interface**
 - A shared runtime system for gestures, state, and command handling
 
@@ -11,7 +11,7 @@ This repo contains:
 
 ## 🚀 Goals
 
-- Create a lightweight, declarative desktop layer on top of NixOS
+- Create a lightweight, declarative desktop layer for Linux, macOS, and Windows
 - Simulate VR/immersive computing with SymbolCast input (gestures & voice)
 - Use devices as personal cloud mesh nodes (e.g., headless laptops)
 - Offer browser-based access for testing, collaboration, and mobile users
@@ -21,11 +21,11 @@ This repo contains:
 ## 📁 Structure
 
 ```plaintext
-nixos/     → Flake + overlays for NixOS DE setup
-web/       → Web version of EtherOS UI (React + Tailwind + Three.js)
-runtime/   → Shared SymbolCast + state logic
-docs/      → Architecture, usage, and planning docs
-nixos/example/   → Small Qt demo showing a native window
+nixos/             → Legacy NixOS configuration
+examples/desktop/  → Qt demo with layered windows and network sync
+web/               → Web version of EtherOS UI (React + Tailwind + Three.js)
+runtime/           → Shared SymbolCast + state logic
+docs/              → Architecture, usage, and planning docs
 ```
 
 
@@ -35,8 +35,8 @@ nixos/example/   → Small Qt demo showing a native window
 
 ### Prerequisites
 
-EtherOS relies on the [Nix package manager](https://nixos.org/download.html).
-Install Nix with flakes enabled before building any part of the project.
+Install [Node.js](https://nodejs.org/) and a Qt6 development environment
+with CMake to build the desktop example and web interface.
 
 
 ### 🔹 Run the Web Version
@@ -55,33 +55,18 @@ npm run build -w runtime
 ```
 The compiled library can then be consumed from `runtime/dist`.
 
-### 🔹 Build NixOS Layer
-
-You must have Nix + flakes enabled.
-```bash
-cd nixos
-nix develop
-nixos-rebuild switch --flake .
-```
-
 ### 🔹 Build the Qt Example
 
-An example Qt application lives in `nixos/example` to verify the native build
-toolchain. From within the Nix shell run:
+An example Qt application lives in `examples/desktop` to verify the native
+build toolchain. It showcases background, middle, and foreground layers with a
+small control panel to choose the interactive layer and UDP-based network
+sync. Build it with:
 
 ```bash
-cd nixos
-nix develop
-cd example
+cd examples/desktop
 cmake -B build
 cmake --build build
 ./build/etheros-example
-```
-You can also compile the demo with a single command using the Nix flake:
-
-```bash
-nix build .#packages.$(nix eval --impure --raw --expr 'builtins.currentSystem').qtExample
-./result/bin/etheros-example
 ```
 
 ### Environment Assets
@@ -91,22 +76,18 @@ The list of available environments lives in `shared/environments.json`. Add your
 ---
 
 ## 🌌 MVP Features (WIP)
-	•	Modular folder structure
-	•	Basic desktop layout in web
-	•	SymbolCast input (mock gestures + voice)
-	•	NixOS flake for personal DE boot
-	•	Shared command & file system logic
-	•       Voice-enabled command palette
-	•       Local AI model dashboard
-
----
+- Modular folder structure
+- Basic desktop layout in web
+- SymbolCast input (mock gestures + voice)
+- Cross-platform build scripts
+- Shared command & file system logic
+- Voice-enabled command palette
+- Local AI model dashboard
 
 ## 📚 Documentation
-	•	docs/architecture.md – Full system vision
-	•	docs/roadmap.md – MVP goals + phases
-	•	docs/usage.md – Dev setup for Nix & Web
-
----
+- docs/architecture.md – Full system vision
+- docs/roadmap.md – MVP goals + phases
+- docs/usage.md – Dev setup for desktop & web
 
 ## 🤝 Contributing
 

--- a/examples/desktop/CMakeLists.txt
+++ b/examples/desktop/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(etheros-example)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Network)
+set(CMAKE_AUTOMOC ON)
+add_executable(etheros-example main.cpp)
+target_link_libraries(etheros-example PRIVATE Qt6::Widgets Qt6::Network)

--- a/examples/desktop/main.cpp
+++ b/examples/desktop/main.cpp
@@ -1,0 +1,141 @@
+#include <QApplication>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QWidget>
+#include <QObject>
+#include <QUdpSocket>
+#include <QNetworkDatagram>
+#include <QCursor>
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
+// Desktop Qt demo with three independent layers (background, middle,
+// foreground) and a control panel to select which layer is interactive.
+// Non-active layers ignore mouse events so input falls through to the chosen
+// window. Layer changes are broadcast over UDP so peers on the local network
+// stay in sync.
+
+class NetworkStorage : public QObject {
+    Q_OBJECT
+public:
+    NetworkStorage(QObject* parent = nullptr) : QObject(parent) {
+        socket.bind(45454, QUdpSocket::ShareAddress);
+        connect(&socket, &QUdpSocket::readyRead, this, &NetworkStorage::onReady);
+    }
+
+    void publish(const QString& layer) {
+        socket.writeDatagram(layer.toUtf8(), QHostAddress::Broadcast, 45454);
+    }
+
+signals:
+    void layerChanged(const QString& layer);
+
+private slots:
+    void onReady() {
+        while (socket.hasPendingDatagrams()) {
+            QNetworkDatagram d = socket.receiveDatagram();
+            emit layerChanged(QString::fromUtf8(d.data()));
+        }
+    }
+
+private:
+    QUdpSocket socket;
+};
+
+// Very basic wallpaper setter placeholder.
+void setWallpaper(const QString& path) {
+#ifdef Q_OS_WIN
+    SystemParametersInfoW(SPI_SETDESKWALLPAPER, 0, (void*)path.utf16(),
+                          SPIF_UPDATEINIFILE | SPIF_SENDWININICHANGE);
+#else
+    Q_UNUSED(path);
+    // TODO: implement for macOS and Linux using platform APIs.
+#endif
+}
+
+// Example cursor control utility.
+void moveCursor(int x, int y) {
+    QCursor::setPos(x, y);
+}
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+
+    NetworkStorage storage;
+    setWallpaper("wallpaper.jpg");
+
+    // Background layer simulating a wallpaper.
+    QWidget background;
+    background.setWindowTitle("Background Layer");
+    background.resize(800, 600);
+    background.setStyleSheet("background-color: #003366;");
+    background.setWindowFlag(Qt::WindowStaysOnBottomHint);
+    background.show();
+
+    // Middle layer representing an application window.
+    QWidget middle;
+    middle.setWindowTitle("Middle Layer");
+    middle.resize(400, 300);
+    middle.move(200, 150);
+    QLabel midLabel("Middleware App", &middle);
+    QVBoxLayout midLayout;
+    midLayout.addWidget(&midLabel);
+    middle.setLayout(&midLayout);
+    middle.show();
+
+    // Foreground layer for gesture or cursor interaction.
+    QWidget foreground;
+    foreground.setWindowTitle("Foreground Layer");
+    foreground.resize(800, 600);
+    foreground.setWindowFlag(Qt::FramelessWindowHint);
+    foreground.setWindowFlag(Qt::Tool);
+    foreground.setWindowFlag(Qt::WindowStaysOnTopHint);
+    foreground.setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    foreground.show();
+
+    // Control panel with buttons to select the active layer.
+    QWidget panel;
+    panel.setWindowTitle("Layer Control");
+    QVBoxLayout panelLayout;
+    QPushButton toBackground("Background");
+    QPushButton toMiddle("Middle");
+    QPushButton toForeground("Foreground");
+    panelLayout.addWidget(&toBackground);
+    panelLayout.addWidget(&toMiddle);
+    panelLayout.addWidget(&toForeground);
+    panel.setLayout(&panelLayout);
+    panel.show();
+
+    auto setActive = [&](QWidget* target, const QString& name) {
+        background.setAttribute(Qt::WA_TransparentForMouseEvents, target != &background);
+        middle.setAttribute(Qt::WA_TransparentForMouseEvents, target != &middle);
+        foreground.setAttribute(Qt::WA_TransparentForMouseEvents, target != &foreground);
+        target->raise();
+        target->activateWindow();
+        storage.publish(name);
+        if (target == &foreground) {
+            QApplication::setOverrideCursor(Qt::CrossCursor);
+            moveCursor(foreground.width() / 2, foreground.height() / 2);
+        } else {
+            QApplication::restoreOverrideCursor();
+        }
+    };
+
+    QObject::connect(&toBackground, &QPushButton::clicked, [&]() { setActive(&background, "background"); });
+    QObject::connect(&toMiddle, &QPushButton::clicked, [&]() { setActive(&middle, "middle"); });
+    QObject::connect(&toForeground, &QPushButton::clicked, [&]() { setActive(&foreground, "foreground"); });
+
+    QObject::connect(&storage, &NetworkStorage::layerChanged, [&](const QString& layer) {
+        if (layer == "background") setActive(&background, layer);
+        else if (layer == "middle") setActive(&middle, layer);
+        else if (layer == "foreground") setActive(&foreground, layer);
+    });
+
+    return app.exec();
+}
+
+#include "main.moc"
+

--- a/nixos/example/CMakeLists.txt
+++ b/nixos/example/CMakeLists.txt
@@ -1,5 +1,0 @@
-cmake_minimum_required(VERSION 3.20)
-project(etheros-example)
-find_package(Qt6 REQUIRED COMPONENTS Widgets)
-add_executable(etheros-example main.cpp)
-target_link_libraries(etheros-example PRIVATE Qt6::Widgets)

--- a/nixos/example/default.nix
+++ b/nixos/example/default.nix
@@ -1,8 +1,0 @@
-{ stdenv, cmake, qt6 }:
-qt6.mkDerivation {
-  pname = "etheros-example";
-  version = "0.1.0";
-  src = ./.;
-  nativeBuildInputs = [ cmake ];
-}
-

--- a/nixos/example/main.cpp
+++ b/nixos/example/main.cpp
@@ -1,9 +1,0 @@
-#include <QApplication>
-#include <QPushButton>
-
-int main(int argc, char** argv) {
-    QApplication app(argc, argv);
-    QPushButton btn("Hello EtherOS");
-    btn.show();
-    return app.exec();
-}


### PR DESCRIPTION
## Summary
- migrate Qt example out of Nix tree into a cross-platform `examples/desktop` demo
- add UDP-based layer sync, wallpaper setter stub, and cursor control
- update README for cross-platform workflow and new demo location

## Testing
- `npm test`
- `cmake -S examples/desktop -B examples/desktop/build`
- `cmake --build examples/desktop/build`


------
https://chatgpt.com/codex/tasks/task_e_689beb933dd8832fa1104ad3d9c7ffd8