### PR TITLE
Add glass foreground and layered windows

### DIFF
--- a/examples/desktop/main.cpp
+++ b/examples/desktop/main.cpp
@@ -2,11 +2,21 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QWidget>
 #include <QObject>
 #include <QUdpSocket>
 #include <QNetworkDatagram>
 #include <QCursor>
+#include <QComboBox>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QGraphicsBlurEffect>
+#include <QPainter>
+#include <QKeyEvent>
+#include <QMouseEvent>
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -16,7 +26,110 @@
 // foreground) and a control panel to select which layer is interactive.
 // Non-active layers ignore mouse events so input falls through to the chosen
 // window. Layer changes are broadcast over UDP so peers on the local network
-// stay in sync.
+// stay in sync. This version also demonstrates a glassy foreground overlay,
+// z-ordered windows, and a simple procedural background module loaded from a
+// JSON environment list.
+
+struct Environment {
+    QString name;
+    QString background;
+    QString module;
+};
+
+QVector<Environment> loadEnvironments() {
+    QFile file("../../shared/environments.json");
+    if (!file.open(QIODevice::ReadOnly)) return {};
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    QVector<Environment> envs;
+    for (auto val : doc.array()) {
+        QJsonObject obj = val.toObject();
+        envs.append({obj.value("name").toString(), obj.value("background").toString(), obj.value("module").toString()});
+    }
+    return envs;
+}
+
+class LayeredWindow : public QWidget {
+    Q_OBJECT
+public:
+    explicit LayeredWindow(const QString& title, QWidget* parent = nullptr) : QWidget(parent) {
+        setWindowTitle(title);
+        z = ++zCounter;
+    }
+
+protected:
+    void mousePressEvent(QMouseEvent* e) override {
+        bringToFront();
+        QWidget::mousePressEvent(e);
+    }
+
+public slots:
+    void bringToFront() {
+        z = ++zCounter;
+        raise();
+        activateWindow();
+    }
+
+private:
+    int z;
+    static int zCounter;
+};
+
+int LayeredWindow::zCounter = 0;
+
+class ProceduralBackground : public QWidget {
+    Q_OBJECT
+public:
+    explicit ProceduralBackground(QWidget* parent = nullptr) : QWidget(parent) {
+        setAttribute(Qt::WA_TranslucentBackground);
+        setFocusPolicy(Qt::StrongFocus);
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override {
+        QPainter p(this);
+        p.setRenderHint(QPainter::Antialiasing);
+        p.fillRect(rect(), Qt::transparent);
+        int size = 60;
+        for (int x = -size * 2; x < width() + size * 2; x += size) {
+            for (int y = -size * 2; y < height() + size * 2; y += size) {
+                QPoint center(x + offset.x(), y + offset.y());
+                QPolygon poly;
+                poly << QPoint(center.x(), center.y() - size / 2)
+                     << QPoint(center.x() + size / 2, center.y())
+                     << QPoint(center.x(), center.y() + size / 2)
+                     << QPoint(center.x() - size / 2, center.y());
+                QColor c((x / size * 10) % 256, (y / size * 10) % 256, 200, 120);
+                p.setBrush(c);
+                p.setPen(Qt::NoPen);
+                p.drawPolygon(poly);
+            }
+        }
+    }
+
+    void keyPressEvent(QKeyEvent* e) override {
+        switch (e->key()) {
+            case Qt::Key_Left:
+                offset.rx() += 10;
+                break;
+            case Qt::Key_Right:
+                offset.rx() -= 10;
+                break;
+            case Qt::Key_Up:
+                offset.ry() += 10;
+                break;
+            case Qt::Key_Down:
+                offset.ry() -= 10;
+                break;
+            default:
+                QWidget::keyPressEvent(e);
+                return;
+        }
+        update();
+    }
+
+private:
+    QPoint offset{0, 0};
+};
 
 class NetworkStorage : public QObject {
     Q_OBJECT
@@ -65,19 +178,18 @@ int main(int argc, char** argv) {
     QApplication app(argc, argv);
 
     NetworkStorage storage;
-    setWallpaper("wallpaper.jpg");
+    auto environments = loadEnvironments();
 
-    // Background layer simulating a wallpaper.
+    // Background layer which may host a procedural module.
     QWidget background;
     background.setWindowTitle("Background Layer");
     background.resize(800, 600);
-    background.setStyleSheet("background-color: #003366;");
     background.setWindowFlag(Qt::WindowStaysOnBottomHint);
+    background.setAttribute(Qt::WA_TranslucentBackground);
     background.show();
 
     // Middle layer representing an application window.
-    QWidget middle;
-    middle.setWindowTitle("Middle Layer");
+    LayeredWindow middle("Middle Layer");
     middle.resize(400, 300);
     middle.move(200, 150);
     QLabel midLabel("Middleware App", &middle);
@@ -86,7 +198,7 @@ int main(int argc, char** argv) {
     middle.setLayout(&midLayout);
     middle.show();
 
-    // Foreground layer for gesture or cursor interaction.
+    // Foreground layer for gesture or cursor interaction with glass effect.
     QWidget foreground;
     foreground.setWindowTitle("Foreground Layer");
     foreground.resize(800, 600);
@@ -94,20 +206,52 @@ int main(int argc, char** argv) {
     foreground.setWindowFlag(Qt::Tool);
     foreground.setWindowFlag(Qt::WindowStaysOnTopHint);
     foreground.setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    foreground.setAttribute(Qt::WA_TranslucentBackground);
+    foreground.setStyleSheet("background-color: rgba(255,255,255,40%);");
+    QGraphicsBlurEffect* blur = new QGraphicsBlurEffect(&foreground);
+    blur->setBlurRadius(20);
+    foreground.setGraphicsEffect(blur);
     foreground.show();
 
-    // Control panel with buttons to select the active layer.
+    // Control panel with buttons and environment selector.
     QWidget panel;
     panel.setWindowTitle("Layer Control");
     QVBoxLayout panelLayout;
     QPushButton toBackground("Background");
     QPushButton toMiddle("Middle");
     QPushButton toForeground("Foreground");
+    QComboBox envSelect;
+    for (const auto& e : environments) envSelect.addItem(e.name);
     panelLayout.addWidget(&toBackground);
     panelLayout.addWidget(&toMiddle);
     panelLayout.addWidget(&toForeground);
+    panelLayout.addWidget(&envSelect);
     panel.setLayout(&panelLayout);
     panel.show();
+
+    ProceduralBackground* procedural = nullptr;
+
+    auto applyEnvironment = [&](int index) {
+        if (index < 0 || index >= environments.size()) return;
+        const Environment& env = environments[index];
+        if (procedural) {
+            procedural->hide();
+            procedural->deleteLater();
+            procedural = nullptr;
+        }
+        if (!env.background.isEmpty()) {
+            setWallpaper(env.background);
+        }
+        if (!env.module.isEmpty()) {
+            procedural = new ProceduralBackground(&background);
+            procedural->setGeometry(background.rect());
+            procedural->show();
+            procedural->setFocus();
+        }
+    };
+
+    QObject::connect(&envSelect, &QComboBox::currentIndexChanged, applyEnvironment);
+    applyEnvironment(envSelect.currentIndex());
 
     auto setActive = [&](QWidget* target, const QString& name) {
         background.setAttribute(Qt::WA_TransparentForMouseEvents, target != &background);

--- a/shared/environments.json
+++ b/shared/environments.json
@@ -1,5 +1,6 @@
 [
   { "id": "rainforest", "name": "Rainforest", "background": "forest.jpg" },
   { "id": "36chambers", "name": "36 Chambers", "background": "chamber.jpg" },
-  { "id": "island", "name": "Island", "background": "island.jpg" }
+  { "id": "island", "name": "Island", "background": "island.jpg" },
+  { "id": "terrain", "name": "Procedural Terrain", "module": "/src/components/ProceduralBackground.tsx" }
 ]

--- a/web/src/components/ForegroundOverlay.tsx
+++ b/web/src/components/ForegroundOverlay.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function ForegroundOverlay() {
+  return (
+    <div className="absolute inset-0 z-10 pointer-events-none bg-white/20 backdrop-blur-lg" />
+  );
+}

--- a/web/src/components/LauncherMenu.tsx
+++ b/web/src/components/LauncherMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { info } from '../logger';
+import Window from './Window';
 
 const apps = [
   { name: 'Terminal', action: () => alert('Terminal launching...') },
@@ -11,7 +12,7 @@ export default function LauncherMenu() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="absolute bottom-4 left-4">
+    <Window className="bottom-4 left-4">
       <button
         className="bg-gray-800 text-white px-3 py-2 rounded"
         onClick={() => {
@@ -44,6 +45,6 @@ export default function LauncherMenu() {
           </ul>
         </div>
       )}
-    </div>
+    </Window>
   );
 }

--- a/web/src/components/ModelDashboard.tsx
+++ b/web/src/components/ModelDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { addModel, listModels, updateModel, Model } from '../../../runtime/src/ai';
+import Window from './Window';
 
 export default function ModelDashboard() {
   const [models, setModels] = useState<Model[]>(listModels());
@@ -21,7 +22,7 @@ export default function ModelDashboard() {
   };
 
   return (
-    <div className="absolute top-4 right-4 bg-white bg-opacity-80 p-2 rounded shadow w-64">
+    <Window className="top-4 right-4 bg-white bg-opacity-80 p-2 rounded shadow w-64">
       <h2 className="font-bold mb-1">Models</h2>
       <div className="flex mb-2">
         <input
@@ -45,6 +46,6 @@ export default function ModelDashboard() {
         ))}
         {models.length === 0 && <li className="text-gray-500">No models</li>}
       </ul>
-    </div>
+    </Window>
   );
 }

--- a/web/src/components/ProceduralBackground.tsx
+++ b/web/src/components/ProceduralBackground.tsx
@@ -30,7 +30,11 @@ function Terrain() {
 
 export default function ProceduralBackground() {
   return (
-    <Canvas className="fixed inset-0 -z-10">
+    <Canvas
+      className="fixed inset-0 -z-20"
+      gl={{ alpha: true }}
+      style={{ background: 'transparent' }}
+    >
       <ambientLight intensity={0.4} />
       <directionalLight position={[5, 10, 5]} />
       <Terrain />

--- a/web/src/components/Window.tsx
+++ b/web/src/components/Window.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+let zCounter = 20;
+
+interface WindowProps {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export default function Window({ children, className = '', style }: WindowProps) {
+  const [z, setZ] = useState(() => ++zCounter);
+
+  const bringToFront = () => {
+    setZ(++zCounter);
+  };
+
+  return (
+    <div
+      className={`absolute ${className}`}
+      style={{ ...style, zIndex: z }}
+      onMouseDown={bringToFront}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -6,16 +6,24 @@ import LauncherMenu from './components/LauncherMenu';
 import CommandPalette from './components/CommandPalette';
 import ModelDashboard from './components/ModelDashboard';
 import ProceduralBackground from './components/ProceduralBackground';
+import ForegroundOverlay from './components/ForegroundOverlay';
 
-const App = () => (
-  <div className="w-screen h-screen relative overflow-hidden">
-    <ProceduralBackground />
-    <EnvManager />
-    <LauncherMenu />
-    <CommandPalette />
-    <ModelDashboard />
-  </div>
-);
+const App = () => {
+  const [World, setWorld] = React.useState<React.ComponentType | null>(
+    () => ProceduralBackground
+  );
+
+  return (
+    <div className="w-screen h-screen relative overflow-hidden">
+      {World && <World />}
+      <ForegroundOverlay />
+      <EnvManager onWorldChange={setWorld} />
+      <LauncherMenu />
+      <CommandPalette />
+      <ModelDashboard />
+    </div>
+  );
+};
 
 info('Starting web application');
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## Summary
- add transparent glossy foreground overlay
- introduce window component to manage z-order and depth
- allow environments to load procedural VR backgrounds as wallpaper

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689cadc2d3a4832f915c5017c4134297