### PR TITLE
feat(web): add desktop UI with taskbar and drag-drop

### DIFF
--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import Window from './Window';
+import Taskbar from './Taskbar';
+
+interface Item {
+  id: string;
+  name: string;
+  type: 'file' | 'folder';
+  x: number;
+  y: number;
+  parentId: string | null;
+}
+
+const initialItems: Item[] = [
+  { id: 'file-1', name: 'Notes.txt', type: 'file', x: 40, y: 40, parentId: null },
+  { id: 'folder-1', name: 'Projects', type: 'folder', x: 140, y: 40, parentId: null },
+];
+
+export default function Desktop() {
+  const [items, setItems] = useState<Item[]>(initialItems);
+  const [openFolders, setOpenFolders] = useState<string[]>([]);
+
+  const handleDragStart = (id: string) => (e: React.DragEvent) => {
+    e.dataTransfer.setData('text/plain', id);
+  };
+
+  const handleDesktopDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const id = e.dataTransfer.getData('text/plain');
+    if (!id) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    setItems((prev) =>
+      prev.map((it) =>
+        it.id === id ? { ...it, x, y, parentId: null } : it
+      )
+    );
+  };
+
+  const handleFolderDrop = (folderId: string) => (e: React.DragEvent) => {
+    e.preventDefault();
+    const id = e.dataTransfer.getData('text/plain');
+    if (!id || id === folderId) return;
+    setItems((prev) =>
+      prev.map((it) => (it.id === id ? { ...it, parentId: folderId } : it))
+    );
+  };
+
+  const openFolder = (id: string) => {
+    if (!openFolders.includes(id)) setOpenFolders((prev) => [...prev, id]);
+  };
+  const closeFolder = (id: string) => {
+    setOpenFolders((prev) => prev.filter((f) => f !== id));
+  };
+
+  const folderContents = (folderId: string) =>
+    items.filter((it) => it.parentId === folderId);
+
+  return (
+    <>
+      <div
+        className="absolute inset-0 z-20"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDesktopDrop}
+      >
+        {items
+          .filter((it) => it.parentId === null)
+          .map((it) => (
+            <div
+              key={it.id}
+              draggable
+              onDragStart={handleDragStart(it.id)}
+              onDoubleClick={() => it.type === 'folder' && openFolder(it.id)}
+              onDrop={
+                it.type === 'folder' ? handleFolderDrop(it.id) : undefined
+              }
+              onDragOver={
+                it.type === 'folder' ? (e) => e.preventDefault() : undefined
+              }
+              className="absolute w-16 text-center select-none"
+              style={{ left: it.x, top: it.y }}
+            >
+              <div className="w-16 h-16 bg-white/70 rounded mb-1 flex items-center justify-center">
+                {it.type === 'folder' ? '📁' : '📄'}
+              </div>
+              <span className="text-xs">{it.name}</span>
+            </div>
+          ))}
+        {openFolders.map((id) => {
+          const folder = items.find((it) => it.id === id)!;
+          return (
+            <Window key={id} className="top-24 left-24 w-48 bg-white p-2">
+              <div className="font-bold mb-2 flex justify-between">
+                {folder.name}
+                <button onClick={() => closeFolder(id)}>×</button>
+              </div>
+              <ul>
+                {folderContents(id).map((child) => (
+                  <li key={child.id}>{child.name}</li>
+                ))}
+              </ul>
+            </Window>
+          );
+        })}
+      </div>
+      <Taskbar
+        openFolders={openFolders.map(
+          (id) => items.find((it) => it.id === id)?.name || id
+        )}
+      />
+    </>
+  );
+}

--- a/web/src/components/Taskbar.tsx
+++ b/web/src/components/Taskbar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import LauncherMenu from './LauncherMenu';
+
+interface TaskbarProps {
+  /** Names of open windows to display */
+  openFolders: string[];
+}
+
+export default function Taskbar({ openFolders }: TaskbarProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 h-10 bg-gray-900 text-white flex items-center px-2 space-x-2 z-30">
+      <LauncherMenu />
+      {openFolders.map((name) => (
+        <div
+          key={name}
+          className="bg-gray-700 px-2 py-1 rounded text-sm"
+        >
+          {name}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/__tests__/Desktop.test.tsx
+++ b/web/src/components/__tests__/Desktop.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import Desktop from '../Desktop';
+
+test('renders default desktop icons', () => {
+  render(<Desktop />);
+  expect(screen.getByText('Notes.txt')).toBeInTheDocument();
+  expect(screen.getByText('Projects')).toBeInTheDocument();
+});

--- a/web/src/components/__tests__/Taskbar.test.tsx
+++ b/web/src/components/__tests__/Taskbar.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { it, expect } from 'vitest';
+import Taskbar from '../Taskbar';
+
+it('shows start button and open folders', () => {
+  render(<Taskbar openFolders={['Projects']} />);
+  expect(screen.getByText('Start')).toBeInTheDocument();
+  expect(screen.getByText('Projects')).toBeInTheDocument();
+});

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { info } from './logger';
 import ReactDOM from 'react-dom/client';
 import EnvManager from './components/EnvManager';
-import LauncherMenu from './components/LauncherMenu';
 import CommandPalette from './components/CommandPalette';
 import ModelDashboard from './components/ModelDashboard';
 import ProceduralBackground from './components/ProceduralBackground';
 import ForegroundOverlay from './components/ForegroundOverlay';
+import Desktop from './components/Desktop';
 
 const App = () => {
   const [World, setWorld] = React.useState<React.ComponentType | null>(
@@ -17,8 +17,8 @@ const App = () => {
     <div className="w-screen h-screen relative overflow-hidden">
       {World && <World />}
       <ForegroundOverlay />
+      <Desktop />
       <EnvManager onWorldChange={setWorld} />
-      <LauncherMenu />
       <CommandPalette />
       <ModelDashboard />
     </div>


### PR DESCRIPTION
## Summary
- add Desktop component with draggable file and folder icons
- show open folders in new Taskbar with Start menu
- wire desktop into app alongside procedural 3D background

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689dfef5b0dc832f96c7c15f2831d8dd