### PR TITLE
Add search API stub and SymbolCast mock daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules/
 # Build outputs
 **/dist/
+# Rust build artifacts
+**/target/
 # Logs
 npm-debug.log*
 # IDE/editor directories

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -10,7 +10,12 @@ axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-tonic = { version = "0.11", features = ["transport"] }
+glob = "0.3"
+hyper = { version = "1", features = ["full"] }
+eco-core = { path = "../../engines/eco-core" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "1.0"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -1,8 +1,33 @@
+mod search;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
 use axum::{routing::get, Json, Router};
-use serde::Serialize;
+use search::{SearchError, SearchIndex, WorldCard};
+use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use tracing::info;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::net::TcpListener;
+use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
+
+#[derive(Clone)]
+struct AppState {
+    search: Arc<SearchIndex>,
+}
+
+#[derive(Debug, Error)]
+enum ApiError {
+    #[error("search initialisation failed: {0}")]
+    Search(#[from] SearchError),
+    #[error("invalid listen address: {0}")]
+    Addr(#[from] std::net::AddrParseError),
+    #[error("failed to bind listener: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("server error: {0}")]
+    Server(#[from] hyper::Error),
+}
 
 #[derive(Debug, Serialize)]
 struct HealthResponse {
@@ -11,19 +36,28 @@ struct HealthResponse {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), ApiError> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 
-    let app = Router::new().route("/health", get(health));
+    let search = SearchIndex::bootstrap_from_examples()?;
+    let state = AppState {
+        search: Arc::new(search),
+    };
 
-    let addr: SocketAddr = "127.0.0.1:8080".parse().expect("valid address");
-    info!("eco-api listening", %addr);
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .expect("server to run");
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/query", get(query))
+        .with_state(state);
+
+    let addr: SocketAddr = std::env::var("ECO_API_ADDR")
+        .unwrap_or_else(|_| "127.0.0.1:8080".to_string())
+        .parse()?;
+    let listener = TcpListener::bind(addr).await?;
+    info!(%addr, "eco-api listening");
+    axum::serve(listener, app.into_make_service()).await?;
+    Ok(())
 }
 
 async fn health() -> Json<HealthResponse> {
@@ -33,13 +67,68 @@ async fn health() -> Json<HealthResponse> {
     })
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct QueryResponse {
+    results: Vec<WorldCard>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryParams {
+    q: String,
+    limit: Option<usize>,
+}
+
+async fn query(
+    State(state): State<AppState>,
+    Query(params): Query<QueryParams>,
+) -> Result<Json<QueryResponse>, (StatusCode, String)> {
+    let limit = params.limit.unwrap_or(5).clamp(1, 25);
+    match state.search.search(&params.q, limit) {
+        Ok(results) => Ok(Json(QueryResponse { results })),
+        Err(err) => {
+            let status = err.status_code();
+            warn!(?err, "search query failed");
+            Err((status, err.to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::util::ServiceExt;
 
     #[tokio::test]
     async fn health_route() {
         let Json(resp) = health().await;
         assert_eq!(resp.status, "ok");
+    }
+
+    #[tokio::test]
+    async fn query_route_returns_results() {
+        let state = AppState {
+            search: Arc::new(SearchIndex::bootstrap_from_examples().expect("bootstrap")),
+        };
+        let app = Router::new().route("/query", get(query)).with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/query?q=Aurora")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("body bytes");
+        let payload: QueryResponse = serde_json::from_slice(&bytes).expect("deserialize response");
+        assert!(!payload.results.is_empty());
     }
 }

--- a/services/api/src/search.rs
+++ b/services/api/src/search.rs
@@ -1,0 +1,135 @@
+use std::path::{Path, PathBuf};
+
+use eco_core::EcoManifest;
+use glob::glob;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldCard {
+    pub id: String,
+    pub name: String,
+    pub summary: String,
+    pub entry_scene: String,
+    pub portals: Vec<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum SearchError {
+    #[error("manifest load failed: {0}")]
+    Manifest(#[from] eco_core::manifest::ManifestError),
+    #[error("glob pattern error: {0}")]
+    Pattern(#[from] glob::PatternError),
+    #[error("glob iteration error: {0}")]
+    Glob(#[from] glob::GlobError),
+}
+
+impl SearchError {
+    pub fn status_code(&self) -> axum::http::StatusCode {
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    }
+}
+
+#[derive(Clone)]
+pub struct SearchIndex {
+    cards: Vec<WorldCard>,
+}
+
+impl SearchIndex {
+    pub fn bootstrap_from_examples() -> Result<Self, SearchError> {
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let pattern = base
+            .join("../../examples/worlds/*/ECO.toml")
+            .display()
+            .to_string();
+
+        let mut cards = Vec::new();
+        for entry in glob(&pattern)? {
+            let manifest_path = entry?;
+            let manifest = EcoManifest::load_from_path(&manifest_path)?;
+            let world_id = Self::infer_world_id(&manifest_path, &manifest);
+            cards.push(WorldCard {
+                id: world_id,
+                name: manifest.name.clone(),
+                summary: format!(
+                    "{} v{} with {} portals",
+                    manifest.name,
+                    manifest.version,
+                    manifest.portals.len()
+                ),
+                entry_scene: manifest.entry_scene.clone(),
+                portals: manifest
+                    .portals
+                    .iter()
+                    .map(|portal| portal.target.clone())
+                    .collect(),
+            });
+        }
+
+        Ok(Self { cards })
+    }
+
+    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<WorldCard>, SearchError> {
+        if query.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let needle = query.to_lowercase();
+        let mut matches: Vec<(usize, WorldCard)> = self
+            .cards
+            .iter()
+            .filter_map(|card| Self::score_card(card, &needle).map(|score| (score, card.clone())))
+            .collect();
+
+        matches.sort_by_key(|(score, card)| (*score, card.name.clone()));
+        matches.truncate(limit);
+        Ok(matches.into_iter().map(|(_, card)| card).collect())
+    }
+
+    fn score_card(card: &WorldCard, query: &str) -> Option<usize> {
+        let mut best = usize::MAX;
+
+        for field in [&card.name, &card.summary, &card.entry_scene] {
+            if let Some(score) = Self::field_position(field, query) {
+                best = best.min(score);
+            }
+        }
+
+        for portal in &card.portals {
+            if let Some(score) = Self::field_position(portal, query) {
+                best = best.min(score + 1);
+            }
+        }
+
+        if best == usize::MAX {
+            None
+        } else {
+            Some(best)
+        }
+    }
+
+    fn field_position(text: &str, query: &str) -> Option<usize> {
+        let haystack = text.to_lowercase();
+        haystack.find(query)
+    }
+
+    fn infer_world_id(path: &Path, manifest: &EcoManifest) -> String {
+        path.parent()
+            .and_then(|p| p.file_name())
+            .and_then(|name| name.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| manifest.name.to_lowercase().replace(' ', "-"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_examples_into_index() {
+        let index = SearchIndex::bootstrap_from_examples().expect("bootstrap search index");
+        let results = index.search("Aurora", 5).expect("search results");
+        assert!(results.iter().any(|card| card.id == "aurora"));
+    }
+}

--- a/tools/symbolcast/Cargo.toml
+++ b/tools/symbolcast/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "symbolcastd"
+version = "0.1.0"
+edition = "2021"
+description = "Mock SymbolCast daemon cycling through gestures and publishing actions"
+license = "MIT"
+
+[dependencies]
+async-nats = "0.33"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["full"] }
+tonic = { version = "0.11", features = ["transport"] }
+prost = "0.12"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
+[build-dependencies]
+tonic-build = "0.11"

--- a/tools/symbolcast/README.md
+++ b/tools/symbolcast/README.md
@@ -1,3 +1,14 @@
 # SymbolCast Studio
 
-The SymbolCast tooling package hosts ONNX model training notebooks and dataset utilities. Upcoming iterations will expose a Web UI for recording gestures, training models with PyTorch, and exporting optimized runtimes for desktop and mobile deployments.
+The SymbolCast tooling package now ships a mock `symbolcastd` daemon alongside future training utilities. The daemon implements the `SymbolCast.Recognize` gRPC service, cycles through a triangle/circle/square gesture set, and publishes mapped actions on `eco.action.cast` so downstream services can react without a real ONNX model.
+
+```bash
+cargo run -p symbolcastd
+```
+
+Environment variables:
+
+- `SYMBOLCASTD_ADDR` – listening address for the gRPC server (default `127.0.0.1:50061`).
+- `NATS_URL` – optional NATS endpoint used to publish `eco.gesture.detected` and `eco.action.cast` events.
+
+Upcoming iterations will add notebooks and recording tools for building real SymbolCast models.

--- a/tools/symbolcast/build.rs
+++ b/tools/symbolcast/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto_dir = std::path::PathBuf::from("../../proto");
+    tonic_build::configure()
+        .build_client(false)
+        .compile(&[proto_dir.join("symbolcast.proto")], &[proto_dir])?;
+    Ok(())
+}

--- a/tools/symbolcast/src/lib.rs
+++ b/tools/symbolcast/src/lib.rs
@@ -1,0 +1,183 @@
+pub mod proto {
+    pub mod symbolcast {
+        tonic::include_proto!("eco.symbolcast");
+    }
+}
+
+use async_nats::Client;
+use proto::symbolcast::symbol_cast_server::{SymbolCast, SymbolCastServer};
+use proto::symbolcast::{Gesture, PointerEvent};
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tonic::{Request, Response, Status};
+use tracing::{debug, info, warn};
+
+const GESTURE_CONFIDENCE: f32 = 0.92;
+const GESTURE_SUBJECT: &str = "eco.gesture.detected";
+const ACTION_SUBJECT: &str = "eco.action.cast";
+
+#[derive(Clone, Copy)]
+struct GestureTemplate {
+    id: &'static str,
+    label: &'static str,
+    action_kind: &'static str,
+    payload: &'static str,
+}
+
+const GESTURE_TEMPLATES: [GestureTemplate; 3] = [
+    GestureTemplate {
+        id: "triangle",
+        label: "Triangle",
+        action_kind: "open_search",
+        payload: "{\"target\":\"search\"}",
+    },
+    GestureTemplate {
+        id: "circle",
+        label: "Circle",
+        action_kind: "snap_panel",
+        payload: "{\"target\":\"panel\"}",
+    },
+    GestureTemplate {
+        id: "square",
+        label: "Square",
+        action_kind: "next_portal",
+        payload: "{\"direction\":\"forward\"}",
+    },
+];
+
+#[derive(Debug, Serialize)]
+struct GestureEvent {
+    id: String,
+    label: String,
+    confidence: f32,
+}
+
+#[derive(Debug, Serialize)]
+struct ActionEvent {
+    id: String,
+    kind: String,
+    payload: String,
+    requested_by: &'static str,
+}
+
+#[derive(Clone)]
+pub struct SymbolCastService {
+    cursor: Arc<Mutex<usize>>,
+    nats: Option<Client>,
+}
+
+impl SymbolCastService {
+    pub async fn new() -> Self {
+        let url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string());
+        let nats = match async_nats::connect(url.clone()).await {
+            Ok(client) => {
+                info!(%url, "symbolcastd connected to NATS");
+                Some(client)
+            }
+            Err(err) => {
+                warn!(%url, ?err, "continuing without NATS connection");
+                None
+            }
+        };
+        Self::with_nats(nats)
+    }
+
+    pub fn with_nats(nats: Option<Client>) -> Self {
+        Self {
+            cursor: Arc::new(Mutex::new(0)),
+            nats,
+        }
+    }
+
+    async fn classify(&self, events: Vec<PointerEvent>) -> Gesture {
+        debug!(count = events.len(), "classifying pointer stream");
+        let template = self.next_template().await;
+        self.publish_gesture(template, GESTURE_CONFIDENCE).await;
+        self.publish_action(template).await;
+        Gesture {
+            id: template.id.to_string(),
+            label: template.label.to_string(),
+            confidence: GESTURE_CONFIDENCE,
+        }
+    }
+
+    async fn next_template(&self) -> GestureTemplate {
+        let mut cursor = self.cursor.lock().await;
+        let template = GESTURE_TEMPLATES[*cursor % GESTURE_TEMPLATES.len()];
+        *cursor = (*cursor + 1) % GESTURE_TEMPLATES.len();
+        template
+    }
+
+    async fn publish_gesture(&self, template: GestureTemplate, confidence: f32) {
+        if let Some(client) = &self.nats {
+            let event = GestureEvent {
+                id: template.id.to_string(),
+                label: template.label.to_string(),
+                confidence,
+            };
+            match serde_json::to_vec(&event) {
+                Ok(bytes) => {
+                    if let Err(err) = client.publish(GESTURE_SUBJECT, bytes.into()).await {
+                        warn!(?err, "failed to publish gesture event");
+                    }
+                }
+                Err(err) => warn!(?err, "failed to serialise gesture event"),
+            }
+        }
+    }
+
+    async fn publish_action(&self, template: GestureTemplate) {
+        if let Some(client) = &self.nats {
+            let event = ActionEvent {
+                id: format!("action-{}", template.id),
+                kind: template.action_kind.to_string(),
+                payload: template.payload.to_string(),
+                requested_by: "symbolcastd",
+            };
+            match serde_json::to_vec(&event) {
+                Ok(bytes) => {
+                    if let Err(err) = client.publish(ACTION_SUBJECT, bytes.into()).await {
+                        warn!(?err, "failed to publish action event");
+                    }
+                }
+                Err(err) => warn!(?err, "failed to serialise action event"),
+            }
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl SymbolCast for SymbolCastService {
+    async fn recognize(
+        &self,
+        request: Request<tonic::Streaming<PointerEvent>>,
+    ) -> Result<Response<Gesture>, Status> {
+        let mut stream = request.into_inner();
+        let mut events = Vec::new();
+        while let Some(event) = stream.message().await? {
+            debug!(x = event.x, y = event.y, pressure = event.pressure, device = %event.device_id, "received pointer event");
+            events.push(event);
+        }
+        let gesture = self.classify(events).await;
+        Ok(Response::new(gesture))
+    }
+}
+
+pub fn server(service: SymbolCastService) -> SymbolCastServer<SymbolCastService> {
+    SymbolCastServer::new(service)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cycles_gestures() {
+        let service = SymbolCastService::with_nats(None);
+        let first = service.classify(Vec::new()).await;
+        let second = service.classify(Vec::new()).await;
+        assert_eq!(first.id, "triangle");
+        assert_eq!(second.id, "circle");
+    }
+}

--- a/tools/symbolcast/src/main.rs
+++ b/tools/symbolcast/src/main.rs
@@ -1,0 +1,18 @@
+use symbolcastd::{server, SymbolCastService};
+use tonic::transport::Server;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let addr: std::net::SocketAddr = std::env::var("SYMBOLCASTD_ADDR")
+        .unwrap_or_else(|_| "127.0.0.1:50061".to_string())
+        .parse()?;
+    let service = SymbolCastService::new().await;
+    info!(%addr, "symbolcastd mock listening");
+    Server::builder()
+        .add_service(server(service))
+        .serve(addr)
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a manifest-driven search index to eco-api and expose a /query route backed by in-memory filtering of example manifests
- introduce a symbolcastd mock daemon crate that implements the SymbolCast gRPC service, cycles gestures, and publishes mapped events
- document the mock daemon usage and ignore Rust target directories

## Testing
- cargo test --manifest-path services/api/Cargo.toml
- cargo test --manifest-path tools/symbolcast/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68cb1597c2d8832f8e02cc9dc9d110c0