### PR TITLE
Ensure guild creation assigns authenticated owner

### DIFF
--- a/apps/web/ethos/backend/routes/guilds.js
+++ b/apps/web/ethos/backend/routes/guilds.js
@@ -7,7 +7,11 @@ router.use(authenticateToken);
 
 router.post('/', async (req, res) => {
   try {
-    const guild = await guilds.create(req.body);
+    const { owner_id: _ignoredOwnerId, ...clientData } = req.body;
+    const guild = await guilds.create({
+      ...clientData,
+      owner_id: req.user.userId
+    });
     res.status(201).json(guild);
   } catch (err) {
     res.status(500).json({ error: 'failed to create guild' });

--- a/apps/web/ethos/backend/tests/guildRoutes.test.js
+++ b/apps/web/ethos/backend/tests/guildRoutes.test.js
@@ -1,0 +1,47 @@
+const { newDb } = require('pg-mem');
+const fs = require('fs');
+const path = require('path');
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+const express = require('express');
+
+const db = newDb();
+const mockPg = db.adapters.createPg();
+jest.mock('pg', () => mockPg);
+
+const { pool } = require('../db');
+const guildRouter = require('../routes/guilds');
+
+const app = express();
+app.use(express.json());
+app.use('/api/guilds', guildRouter);
+
+beforeAll(async () => {
+  const sql1 = fs.readFileSync(path.join(__dirname, '../migrations/001-init.sql'), 'utf8');
+  const sql2 = fs.readFileSync(path.join(__dirname, '../migrations/006-guild-memberships.sql'), 'utf8');
+  await pool.query(sql1);
+  await pool.query(sql2);
+  await pool.query("INSERT INTO users (email, hashed_password) VALUES ('owner@example.com','x')");
+});
+
+test('guild creator becomes owner and gains approved membership', async () => {
+  const token = jwt.sign({ userId: 1 }, 'secret');
+
+  const res = await request(app)
+    .post('/api/guilds')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ name: 'Server Guild', description: 'desc', owner_id: 999 });
+
+  expect(res.status).toBe(201);
+  expect(res.body.name).toBe('Server Guild');
+  expect(res.body.owner_id).toBe(1);
+
+  const guildRow = await pool.query('SELECT owner_id FROM guilds WHERE id = $1', [res.body.id]);
+  expect(guildRow.rows[0].owner_id).toBe(1);
+
+  const membershipRows = await pool.query('SELECT * FROM guild_memberships WHERE guild_id = $1', [res.body.id]);
+  expect(membershipRows.rows).toHaveLength(1);
+  expect(membershipRows.rows[0].user_id).toBe(1);
+  expect(membershipRows.rows[0].role).toBe('owner');
+  expect(membershipRows.rows[0].status).toBe('approved');
+});


### PR DESCRIPTION
## Summary
- ensure the guild creation route always uses the authenticated user as the owner
- add an integration test that verifies the creator is saved as owner and receives an approved membership

## Testing
- npm test (apps/web/ethos/backend)


------
https://chatgpt.com/codex/tasks/task_e_68cea4d58854832f9745d65322e9e7a9