### PR TITLE
chore: remove pod-world tsconfig reference

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "files": [],
   "references": [
-    { "path": "./apps/web/pod-world" },
     { "path": "./sdks/js" }
   ]
 }


### PR DESCRIPTION
## Summary
- remove the obsolete tsconfig project reference to apps/web/pod-world

## Testing
- npm run dev (apps/web/ethos/frontend) *(fails: build errors from missing exports in src/api/entities.js, no TSConfck error)*

------
https://chatgpt.com/codex/tasks/task_e_68cea4d204c8832f9ab6774d8fd2367f