### PR TITLE
Add Postgres-backed Ethos auth with registration

### DIFF
--- a/apps/web/ethos/frontend/components/layout/AuthBoundary.tsx
+++ b/apps/web/ethos/frontend/components/layout/AuthBoundary.tsx
@@ -8,17 +8,26 @@ export default function AuthBoundary({
 }: {
   children: React.ReactNode;
 }) {
-  const { status, login, error } = useSessionStore((state) => ({
+  const { status, login, register, error } = useSessionStore((state) => ({
     status: state.status,
     login: state.login,
+    register: state.register,
     error: state.error,
   }));
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [mode, setMode] = useState<"login" | "register">("login");
+
+  const isRegister = mode === "register";
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
-    await login({ email, password });
+    if (isRegister) {
+      await register({ email, password, displayName });
+    } else {
+      await login({ email, password });
+    }
   };
 
   if (status === "authenticated") {
@@ -31,10 +40,12 @@ export default function AuthBoundary({
         onSubmit={onSubmit}
         className="w-full max-w-md space-y-6 rounded-3xl border border-slate-800 bg-slate-900/70 p-8 shadow-xl"
       >
-        <div className="space-y-2">
-          <h1 className="text-2xl font-semibold text-white">Sign in to Ethos</h1>
+        <div className="space-y-2 text-center md:text-left">
+          <h1 className="text-2xl font-semibold text-white">
+            {isRegister ? "Create your Ethos account" : "Sign in to Ethos"}
+          </h1>
           <p className="text-sm text-slate-400">
-            Authenticate with your Ethos JWT to hydrate the Matrix-backed session via the gateway.
+            Use your Ethos credentials to access the Matrix-backed guild experience, or create a new account to get started.
           </p>
         </div>
         <label className="block text-left text-sm font-medium text-slate-300">
@@ -46,6 +57,18 @@ export default function AuthBoundary({
             onChange={(event) => setEmail(event.target.value)}
           />
         </label>
+        {isRegister ? (
+          <label className="block text-left text-sm font-medium text-slate-300">
+            Display name
+            <input
+              className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-4 py-2 text-white focus:border-brand-400 focus:outline-none"
+              type="text"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              placeholder="How should other operatives refer to you?"
+            />
+          </label>
+        ) : null}
         <label className="block text-left text-sm font-medium text-slate-300">
           Password
           <input
@@ -61,8 +84,26 @@ export default function AuthBoundary({
           disabled={status === "loading"}
           className="w-full rounded-full bg-brand-500 py-2 text-sm font-semibold text-white transition hover:bg-brand-400 disabled:cursor-not-allowed disabled:opacity-70"
         >
-          {status === "loading" ? "Signing in…" : "Sign in"}
+          {status === "loading"
+            ? isRegister
+              ? "Creating account…"
+              : "Signing in…"
+            : isRegister
+              ? "Create account"
+              : "Sign in"}
         </button>
+        <p className="text-center text-xs text-slate-400">
+          {isRegister ? "Already have an account?" : "New to Ethos?"}{" "}
+          <button
+            type="button"
+            onClick={() => {
+              setMode(isRegister ? "login" : "register");
+            }}
+            className="font-semibold text-brand-300 hover:text-brand-200"
+          >
+            {isRegister ? "Sign in" : "Create one"}
+          </button>
+        </p>
       </form>
     </div>
   );

--- a/services/ethos-gateway/Cargo.lock
+++ b/services/ethos-gateway/Cargo.lock
@@ -101,6 +101,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae2ed21cd55021f05707a807a5fc85695dafb98832921f6cfa06db67ca5b869"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +756,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.16",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
 name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,12 +926,14 @@ name = "ethos-gateway"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "async-nats",
  "async-stream",
  "async-trait",
  "axum 0.7.9",
  "axum-extra",
  "chrono",
+ "deadpool-postgres",
  "futures",
  "http-body-util",
  "hyper 0.14.32",
@@ -909,6 +946,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -965,6 +1003,12 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -1919,6 +1963,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.9.4",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,7 +2077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
 dependencies = [
  "log",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -2302,6 +2357,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2642,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,7 +2710,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2644,7 +2730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2653,7 +2739,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -2664,7 +2750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -2675,6 +2761,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2743,6 +2838,36 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbef655056b916eb868048276cfd5d6a7dea4f81560dfd047f97c8c6fe3fcfd4"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a120daaabfcb0e324d5bf6e411e9222994cb3795c79943a0ef28ed27ea76e4"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "uuid",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3234,7 +3359,7 @@ checksum = "865afa2321e34fa836ea4c1d77ce0c2bb40f7d13fe18ee3e795091fd8d173a1d"
 dependencies = [
  "as_variant",
  "html5ever",
- "phf",
+ "phf 0.11.3",
  "tracing",
  "wildmatch",
 ]
@@ -3272,7 +3397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
 dependencies = [
  "bitflags 2.9.4",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -3712,7 +3837,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -3724,9 +3849,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -3949,6 +4085,32 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156efe7fff213168257853e1dfde202eed5f487522cbbbf7d219941d753d853"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.2",
+ "socket2 0.6.0",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -4287,6 +4449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4300,6 +4468,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "universal-hash"
@@ -4442,6 +4616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,6 +4742,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/services/ethos-gateway/Cargo.toml
+++ b/services/ethos-gateway/Cargo.toml
@@ -20,6 +20,7 @@ axum = { version = "0.7", features = ["macros", "json", "tokio", "http1"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
 futures = "0.3"
 jsonwebtoken = "9"
+argon2 = { version = "0.5", features = ["std", "password-hash"] }
 prost = "0.12"
 prost-types = "0.12"
 serde = { version = "1.0", features = ["derive"] }
@@ -33,6 +34,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "1.7", features = ["serde", "v4", "v5"] }
 chrono = { version = "0.4", features = ["serde"] }
+deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
+tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
 
 matrix-sdk = { version = "0.13", optional = true }
 

--- a/services/ethos-gateway/migrations/0001_create_users.sql
+++ b/services/ethos-gateway/migrations/0001_create_users.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/services/ethos-gateway/src/config.rs
+++ b/services/ethos-gateway/src/config.rs
@@ -15,6 +15,7 @@ pub struct GatewayConfig {
     pub http_addr: SocketAddr,
     pub grpc_addr: SocketAddr,
     pub nats_url: Option<String>,
+    pub database_url: String,
     pub matrix: Option<MatrixConfig>,
 }
 
@@ -29,6 +30,8 @@ impl GatewayConfig {
             .unwrap_or_else(|_| "0.0.0.0:8081".to_string())
             .parse()?;
         let nats_url = env::var("ETHOS_NATS_URL").ok();
+        let database_url = env::var("ETHOS_DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://ethos:ethos@localhost:5432/ethos".to_string());
 
         let matrix = match env::var("ETHOS_MATRIX_HOMESERVER") {
             Ok(homeserver) => Some(MatrixConfig {
@@ -46,6 +49,7 @@ impl GatewayConfig {
             http_addr,
             grpc_addr,
             nats_url,
+            database_url,
             matrix,
         })
     }

--- a/services/ethos-gateway/src/routes/auth.rs
+++ b/services/ethos-gateway/src/routes/auth.rs
@@ -1,8 +1,15 @@
 use std::sync::Arc;
 
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Extension, Json};
+use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
+use tokio_postgres::{error::SqlState, Row};
+use tracing::error;
 use uuid::Uuid;
 
 use crate::{
@@ -16,6 +23,14 @@ pub struct LoginRequest {
     pub password: String,
     #[serde(default)]
     pub matrix_access_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    pub email: String,
+    pub password: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -36,49 +51,127 @@ pub struct SessionUser {
     pub display_name: Option<String>,
 }
 
+struct DbUser {
+    id: Uuid,
+    email: String,
+    password_hash: String,
+    display_name: Option<String>,
+}
+
+impl DbUser {
+    fn from_row(row: &Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            email: row.try_get("email")?,
+            password_hash: row.try_get("password_hash")?,
+            display_name: row.try_get("display_name")?,
+        })
+    }
+}
+
 pub async fn login(
     Extension(state): Extension<Arc<AppState>>,
     Json(request): Json<LoginRequest>,
 ) -> Result<Json<SessionResponse>, impl IntoResponse> {
-    if request.email.is_empty() || request.password.is_empty() {
+    let LoginRequest {
+        email,
+        password,
+        matrix_access_token,
+    } = request;
+
+    if email.is_empty() || password.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Missing credentials"));
     }
 
-    // For now accept any password and mint a signed JWT. In production integrate with a user directory.
-    let user_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, request.email.as_bytes()).to_string();
-    let claims = auth::Claims {
-        sub: user_id.clone(),
-        email: request.email.clone(),
-        display_name: Some(request.email.clone()),
-        exp: (chrono::Utc::now() + chrono::Duration::hours(12)).timestamp() as usize,
-    };
-    let token = encode(
-        &Header::default(),
-        &claims,
-        &EncodingKey::from_secret(state.config.jwt_secret.as_bytes()),
-    )
-    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Failed to sign token"))?;
+    let client = state.db.get().await.map_err(|error| {
+        error!(error = ?error, "failed to acquire database connection");
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to authenticate")
+    })?;
 
-    Ok(Json(SessionResponse {
-        token,
-        matrix_access_token: request.matrix_access_token.or_else(|| {
-            state
-                .config
-                .matrix
-                .as_ref()
-                .and_then(|cfg| cfg.access_token.clone())
-        }),
-        matrix_homeserver: state
-            .config
-            .matrix
-            .as_ref()
-            .map(|cfg| cfg.homeserver.clone()),
-        user: SessionUser {
-            id: user_id,
-            email: request.email,
-            display_name: Some("Ethos Operative".into()),
-        },
-    }))
+    let row = client
+        .query_opt(
+            "SELECT id, email, password_hash, display_name FROM users WHERE email = $1",
+            &[&email],
+        )
+        .await
+        .map_err(|error| {
+            error!(error = ?error, "failed to fetch user during login");
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to authenticate")
+        })?
+        .ok_or((StatusCode::UNAUTHORIZED, "Invalid credentials"))?;
+    let user = DbUser::from_row(&row).map_err(|error| {
+        error!(error = ?error, "failed to parse user record");
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to authenticate")
+    })?;
+
+    let parsed_hash = PasswordHash::new(&user.password_hash)
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Failed to authenticate"))?;
+    Argon2::default()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid credentials"))?;
+
+    let response = build_session_response(state.as_ref(), &user, matrix_access_token)?;
+
+    Ok(Json(response))
+}
+
+pub async fn register(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(request): Json<RegisterRequest>,
+) -> Result<Json<SessionResponse>, impl IntoResponse> {
+    let RegisterRequest {
+        email,
+        password,
+        display_name,
+    } = request;
+
+    if email.is_empty() || password.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "Missing credentials"));
+    }
+
+    let mut rng = OsRng;
+    let password_hash = Argon2::default()
+        .hash_password(password.as_bytes(), &SaltString::generate(&mut rng))
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Failed to register user"))?
+        .to_string();
+
+    let normalized_display_name = display_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+
+    let client = state.db.get().await.map_err(|error| {
+        error!(error = ?error, "failed to acquire database connection");
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to register user")
+    })?;
+
+    let user_id = Uuid::new_v4();
+    let display_name_param: Option<&str> = normalized_display_name.as_deref();
+    let row = client
+        .query_one(
+            "INSERT INTO users (id, email, password_hash, display_name) VALUES ($1, $2, $3, $4) \
+             RETURNING id, email, password_hash, display_name",
+            &[&user_id, &email, &password_hash, &display_name_param],
+        )
+        .await
+        .map_err(|error| {
+            if let Some(code) = error.code() {
+                if code == &SqlState::UNIQUE_VIOLATION {
+                    return (StatusCode::CONFLICT, "Email already registered");
+                }
+            }
+            error!(error = ?error, "failed to register user");
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to register user")
+        })?;
+    let user = DbUser::from_row(&row).map_err(|error| {
+        error!(error = ?error, "failed to parse user record");
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to register user")
+    })?;
+
+    let response = build_session_response(state.as_ref(), &user, None)?;
+
+    Ok(Json(response))
 }
 
 pub async fn session(
@@ -101,6 +194,50 @@ pub async fn session(
             id: auth.user_id,
             email: auth.email,
             display_name: auth.display_name,
+        },
+    })
+}
+
+fn build_session_response(
+    state: &AppState,
+    user: &DbUser,
+    matrix_override: Option<String>,
+) -> Result<SessionResponse, (StatusCode, &'static str)> {
+    let claims = auth::Claims {
+        sub: user.id.to_string(),
+        email: user.email.clone(),
+        display_name: user.display_name.clone(),
+        exp: (Utc::now() + Duration::hours(12)).timestamp() as usize,
+    };
+
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(state.config.jwt_secret.as_bytes()),
+    )
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Failed to sign token"))?;
+
+    let matrix_access_token = matrix_override.or_else(|| {
+        state
+            .config
+            .matrix
+            .as_ref()
+            .and_then(|cfg| cfg.access_token.clone())
+    });
+    let matrix_homeserver = state
+        .config
+        .matrix
+        .as_ref()
+        .map(|cfg| cfg.homeserver.clone());
+
+    Ok(SessionResponse {
+        token,
+        matrix_access_token,
+        matrix_homeserver,
+        user: SessionUser {
+            id: user.id.to_string(),
+            email: user.email.clone(),
+            display_name: user.display_name.clone(),
         },
     })
 }

--- a/services/ethos-gateway/src/routes/mod.rs
+++ b/services/ethos-gateway/src/routes/mod.rs
@@ -19,6 +19,7 @@ pub fn router(state: AppState) -> Router {
     let shared = Arc::new(state);
     Router::new()
         .route("/auth/login", post(login))
+        .route("/auth/register", post(register))
         .route("/auth/session", get(session))
         .route(
             "/api/conversations",

--- a/services/ethos-gateway/src/state.rs
+++ b/services/ethos-gateway/src/state.rs
@@ -5,10 +5,12 @@ use crate::{
     matrix::MatrixBridge,
     services::{EventPublisher, RoomService},
 };
+use deadpool_postgres::Pool;
 
 #[derive(Clone)]
 pub struct AppState {
     pub config: GatewayConfig,
+    pub db: Pool,
     pub room_service: Arc<dyn RoomService>,
     pub publisher: Arc<dyn EventPublisher>,
     pub matrix: Arc<dyn MatrixBridge>,
@@ -17,12 +19,14 @@ pub struct AppState {
 impl AppState {
     pub fn new(
         config: GatewayConfig,
+        db: Pool,
         room_service: Arc<dyn RoomService>,
         publisher: Arc<dyn EventPublisher>,
         matrix: Arc<dyn MatrixBridge>,
     ) -> Self {
         Self {
             config,
+            db,
             room_service,
             publisher,
             matrix,


### PR DESCRIPTION
## Summary
- add a PostgreSQL pool to the Ethos gateway and persist users for login and registration
- expose a registration endpoint and share session issuance between login flows
- update the Ethos web shell to toggle between sign-in and registration backed by the new store method

## Testing
- cargo check --manifest-path services/ethos-gateway/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d74b93e004832fa5ea63d428676caa