### PR TITLE
Allow Ethos gateway to respect DATABASE_URL fallback

### DIFF
--- a/apps/web/ethos/README.md
+++ b/apps/web/ethos/README.md
@@ -69,6 +69,8 @@ The crate uses an in-memory room service by default and can be compiled with the
 - `ETHOS_HTTP_ADDR` – HTTP listen address (`0.0.0.0:8080` by default)
 - `ETHOS_GRPC_ADDR` – gRPC listen address (`0.0.0.0:8081` by default)
 - `ETHOS_NATS_URL` – Optional NATS connection string for publishing chat events
+- `ETHOS_DATABASE_URL` / `DATABASE_URL` – Postgres connection string for the
+  user store (defaults to `postgres://ethos:ethos@localhost:5432/ethos`)
 - `ETHOS_MATRIX_HOMESERVER` / `ETHOS_MATRIX_ACCESS_TOKEN` – Optional Matrix
   credentials when bridging to a homeserver
 

--- a/services/ethos-gateway/src/config.rs
+++ b/services/ethos-gateway/src/config.rs
@@ -31,6 +31,7 @@ impl GatewayConfig {
             .parse()?;
         let nats_url = env::var("ETHOS_NATS_URL").ok();
         let database_url = env::var("ETHOS_DATABASE_URL")
+            .or_else(|_| env::var("DATABASE_URL"))
             .unwrap_or_else(|_| "postgres://ethos:ethos@localhost:5432/ethos".to_string());
 
         let matrix = match env::var("ETHOS_MATRIX_HOMESERVER") {


### PR DESCRIPTION
## Summary
- allow the gateway configuration to fall back to DATABASE_URL when ETHOS_DATABASE_URL is not set
- document the database connection string environment variable in the Ethos README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8848ea2d0832fb5c7e092f081e663