### PR TITLE
docs: add direnv example for database url

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,11 @@
+# Load database credentials for local development with direnv.
+# Copy this file to `.envrc` and update the connection string if needed.
+# direnv will automatically load the values whenever you `cd` into the repo.
+
+# Prefer sourcing a local .env so secrets stay out of version control.
+if [ -f .env ]; then
+  dotenv .env
+fi
+
+# Fallback to the sample Postgres URL if no .env overrides it.
+export ETHOS_DATABASE_URL=${ETHOS_DATABASE_URL:-"postgres://ethos:ethos@localhost:5432/ethos"}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ direnv allow . # if you use direnv + Nix flakes
 nix develop ./distro/nix   # or install Node.js 20 + Rust + CMake manually
 ```
 
+### Configure Environment Variables
+
+Some services (for example, `services/ethos-gateway`) expect a Postgres
+connection string in `ETHOS_DATABASE_URL`. To avoid manually exporting the
+variable each time, copy the sample files and allow `direnv` to load them when
+you enter the repository:
+
+```bash
+cp .env.na .env                # update the credentials to match your setup
+cp .envrc.example .envrc       # optional; customize as needed
+direnv allow .
+```
+
+The `.envrc.example` file loads `.env` (keeping secrets out of version control)
+and falls back to the default `postgres://ethos:ethos@localhost:5432/ethos`
+URL. You can also set the variable globally via your shell profile or
+`~/.cargo/config.toml` if you prefer not to use `direnv`.
+
 ### Bootstrap workspaces
 
 ```bash


### PR DESCRIPTION
## Summary
- add a checked-in `.envrc.example` to help load Postgres credentials with direnv
- document how to copy the sample env files so `cargo run` picks up `ETHOS_DATABASE_URL`

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d88cf93e70832f93d02cd95cb2c4cd