### PR TITLE
Load .env configuration before starting ethos-gateway

### DIFF
--- a/services/ethos-gateway/Cargo.lock
+++ b/services/ethos-gateway/Cargo.lock
@@ -864,6 +864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +940,7 @@ dependencies = [
  "axum-extra",
  "chrono",
  "deadpool-postgres",
+ "dotenvy",
  "futures",
  "http-body-util",
  "hyper 0.14.32",

--- a/services/ethos-gateway/Cargo.toml
+++ b/services/ethos-gateway/Cargo.toml
@@ -36,6 +36,7 @@ uuid = { version = "1.7", features = ["serde", "v4", "v5"] }
 chrono = { version = "0.4", features = ["serde"] }
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
+dotenvy = "0.15"
 
 matrix-sdk = { version = "0.13", optional = true }
 

--- a/services/ethos-gateway/src/main.rs
+++ b/services/ethos-gateway/src/main.rs
@@ -17,6 +17,8 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();


### PR DESCRIPTION
## Summary
- add the `dotenvy` crate and initialize it during gateway startup
- load `.env` values automatically so local credentials override the default Postgres URL

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d8969975dc832fa2aff125059642f2