### PR TITLE
Add CORS support to ethos gateway

### DIFF
--- a/services/ethos-gateway/Cargo.lock
+++ b/services/ethos-gateway/Cargo.lock
@@ -959,6 +959,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower 0.4.13",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3200,7 +3201,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4314,6 +4315,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/services/ethos-gateway/Cargo.toml
+++ b/services/ethos-gateway/Cargo.toml
@@ -32,6 +32,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 tonic = { version = "0.10", features = ["transport"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tower-http = { version = "0.5", features = ["cors"] }
 uuid = { version = "1.7", features = ["serde", "v4", "v5"] }
 chrono = { version = "0.4", features = ["serde"] }
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }

--- a/services/ethos-gateway/src/routes/mod.rs
+++ b/services/ethos-gateway/src/routes/mod.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
 use axum::{
+    http::{header, Method},
     routing::{get, post},
     Extension, Router,
 };
+use tower_http::cors::{Any, CorsLayer};
 
 use crate::state::AppState;
 
@@ -17,6 +19,11 @@ pub use stream::*;
 
 pub fn router(state: AppState) -> Router {
     let shared = Arc::new(state);
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+
     Router::new()
         .route("/auth/login", post(login))
         .route("/auth/register", post(register))
@@ -30,6 +37,7 @@ pub fn router(state: AppState) -> Router {
             get(list_messages).post(post_message),
         )
         .route("/api/conversations/:id/stream", get(stream_conversation))
+        .layer(cors)
         .layer(Extension(shared.clone()))
         .with_state(shared)
 }


### PR DESCRIPTION
## Summary
- add the tower-http dependency so the ethos gateway can expose CORS configuration
- apply a permissive CORS layer to the HTTP router to allow browser clients to call the API endpoints

## Testing
- cargo check --manifest-path services/ethos-gateway/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d89a3a274c832f866a1f04243a37e4