### PR TITLE
Ensure legacy user tables include optional columns

### DIFF
--- a/services/ethos-gateway/migrations/0001_create_users.sql
+++ b/services/ethos-gateway/migrations/0001_create_users.sql
@@ -5,3 +5,18 @@ CREATE TABLE IF NOT EXISTS users (
     display_name TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Ensure legacy databases gain the newer optional columns.
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS display_name TEXT;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+
+UPDATE users SET created_at = NOW() WHERE created_at IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN created_at SET DEFAULT NOW();
+
+ALTER TABLE users
+    ALTER COLUMN created_at SET NOT NULL;


### PR DESCRIPTION
## Summary
- update the user table migration to add the `display_name` and `created_at` columns when they are missing
- make sure existing rows receive a `created_at` value and keep the default in place for future inserts

## Testing
- `curl -s -o /tmp/register9.json -w "%{http_code}\n" -X POST http://localhost:8080/auth/register -H "Content-Type: application/json" -d '{"email":"user6@example.com","password":"password"}'`


------
https://chatgpt.com/codex/tasks/task_e_68d89db9e9d0832fa2eb71808d8873f0