### PR TITLE
Refactor gateway migration handling

### DIFF
--- a/services/ethos-gateway/src/lib.rs
+++ b/services/ethos-gateway/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod config;
 pub mod grpc;
 pub mod matrix;
+pub mod migrations;
 pub mod routes;
 pub mod services;
 pub mod state;

--- a/services/ethos-gateway/src/migrations.rs
+++ b/services/ethos-gateway/src/migrations.rs
@@ -1,0 +1,20 @@
+use anyhow::Context;
+use deadpool_postgres::Pool;
+
+const MIGRATIONS: &[&str] = &[include_str!("../migrations/0001_create_users.sql")];
+
+pub async fn run_migrations(pool: &Pool) -> anyhow::Result<()> {
+    let client = pool
+        .get()
+        .await
+        .context("failed to acquire postgres client for migrations")?;
+
+    for migration in MIGRATIONS {
+        client
+            .batch_execute(migration)
+            .await
+            .context("failed to execute database migration")?;
+    }
+
+    Ok(())
+}

--- a/services/ethos-gateway/src/routes/auth.rs
+++ b/services/ethos-gateway/src/routes/auth.rs
@@ -160,6 +160,21 @@ pub async fn register(
                 if code == &SqlState::UNIQUE_VIOLATION {
                     return (StatusCode::CONFLICT, "Email already registered");
                 }
+                if matches!(
+                    code,
+                    &SqlState::UNDEFINED_TABLE
+                        | &SqlState::UNDEFINED_COLUMN
+                        | &SqlState::INVALID_SCHEMA_NAME
+                ) {
+                    error!(
+                        error = ?error,
+                        "failed to register user because database schema is unavailable"
+                    );
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Registration temporarily unavailable while the service initializes",
+                    );
+                }
             }
             error!(error = ?error, "failed to register user");
             (StatusCode::INTERNAL_SERVER_ERROR, "Failed to register user")


### PR DESCRIPTION
## Summary
- add a reusable `run_migrations` helper and call it during gateway startup
- exercise the migration helper from the integration test harness when constructing the app state
- surface a 503 response when registration fails because the database schema is unavailable

## Testing
- not run (PostgreSQL required)


------
https://chatgpt.com/codex/tasks/task_e_68d8a73a70d0832f9be53f92c9025f85