### PR TITLE
Ensure password hash column backfills for legacy schemas

### DIFF
--- a/services/ethos-gateway/migrations/0001_create_users.sql
+++ b/services/ethos-gateway/migrations/0001_create_users.sql
@@ -8,6 +8,9 @@ CREATE TABLE IF NOT EXISTS users (
 
 -- Ensure legacy databases gain the newer optional columns.
 ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS password_hash TEXT;
+
+ALTER TABLE users
     ADD COLUMN IF NOT EXISTS display_name TEXT;
 
 ALTER TABLE users
@@ -20,3 +23,15 @@ ALTER TABLE users
 
 ALTER TABLE users
     ALTER COLUMN created_at SET NOT NULL;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM users WHERE password_hash IS NULL) THEN
+        RAISE EXCEPTION 'users.password_hash must be populated before running this migration'
+            USING HINT = 'Populate users.password_hash for existing accounts and re-run the migration.';
+    END IF;
+END;
+$$;
+
+ALTER TABLE users
+    ALTER COLUMN password_hash SET NOT NULL;


### PR DESCRIPTION
## Summary
- add a legacy-safe migration step that creates the users.password_hash column when it is missing
- fail the migration when legacy rows still lack hashes before enforcing the NOT NULL constraint

## Testing
- `cargo run --bin ethos-gateway`
- `curl -s -o /tmp/register.json -w "%{http_code}" -X POST http://127.0.0.1:4000/auth/register -H 'content-type: application/json' -d '{"email":"newuser@example.com","password":"password123"}'`


------
https://chatgpt.com/codex/tasks/task_e_68d8acd1a478832fb159be30b9db2652