### PR TITLE
Fix auth route result types to avoid IntoResponse inference conflicts

### DIFF
--- a/services/ethos-gateway/src/routes/auth.rs
+++ b/services/ethos-gateway/src/routes/auth.rs
@@ -81,7 +81,7 @@ impl DbUser {
 pub async fn login(
     Extension(state): Extension<Arc<AppState>>,
     Json(request): Json<LoginRequest>,
-) -> Result<Json<SessionResponse>, impl IntoResponse> {
+) -> Result<Json<SessionResponse>, (StatusCode, &'static str)> {
     let LoginRequest {
         email,
         password,
@@ -127,7 +127,7 @@ pub async fn login(
 pub async fn register(
     Extension(state): Extension<Arc<AppState>>,
     Json(request): Json<RegisterRequest>,
-) -> Result<Json<SessionResponse>, impl IntoResponse> {
+) -> Result<Json<SessionResponse>, (StatusCode, &'static str)> {
     let RegisterRequest {
         email,
         password,
@@ -201,7 +201,7 @@ pub async fn register(
 pub async fn guest_login(
     Extension(state): Extension<Arc<AppState>>,
     Json(request): Json<GuestLoginRequest>,
-) -> Result<Json<SessionResponse>, impl IntoResponse> {
+) -> Result<Json<SessionResponse>, (StatusCode, &'static str)> {
     let mut rng = OsRng;
     let password = Uuid::new_v4().to_string();
     let password_hash = Argon2::default()


### PR DESCRIPTION
## Summary
- specify explicit error type for login, register, and guest login route handlers to avoid IntoResponse inference issues when multiple axum versions are in the dependency graph

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d9d086489c832f952d6d06877da4d3