### PR TITLE
Fix login page signup link

### DIFF
--- a/apps/web/ethos/frontend/app/login/page.tsx
+++ b/apps/web/ethos/frontend/app/login/page.tsx
@@ -124,7 +124,7 @@ export default function LoginPage() {
         <CardFooter className="flex flex-col space-y-2 text-center text-sm text-muted-foreground">
           <p>
             Need an account?{" "}
-            <Link href="https://ethos.e-co.app/signup" className="font-medium text-primary hover:underline">
+            <Link href="/signup" className="font-medium text-primary hover:underline">
               Request access
             </Link>
           </p>


### PR DESCRIPTION
## Summary
- update the "Request access" link on the login page to use the in-app /signup route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9d86a3d04832fbc10620762e6b8fe