### PR TITLE
Fix user identity fallback so authenticated users aren’t shown as guests

### DIFF
--- a/apps/web/ethos/frontend/api/client.js
+++ b/apps/web/ethos/frontend/api/client.js
@@ -30,7 +30,12 @@ export async function request(path, options = {}) {
   const res = await fetch(`${API_URL}${path}`, { ...options, headers });
   if (!res.ok) {
     const message = await res.text();
-    throw new Error(message || 'Request failed');
+    const error = new Error(message || 'Request failed');
+    // Attach the HTTP status code so callers can branch on specific failures.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore – this file is plain JS so we can annotate ad-hoc properties.
+    error.status = res.status;
+    throw error;
   }
   if (res.status === 204 || res.status === 205) {
     return null;

--- a/apps/web/ethos/frontend/ethos-pages/Layout.jsx
+++ b/apps/web/ethos/frontend/ethos-pages/Layout.jsx
@@ -119,6 +119,13 @@ export default function Layout({ children, currentPageName: propCurrentPageName 
   const [tutorialStep, setTutorialStep] = useState(0);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
+  const resolvedUserName =
+    currentUser?.full_name ||
+    currentUser?.display_name ||
+    currentUser?.username ||
+    (currentUser?.email ? currentUser.email.split('@')[0] : null) ||
+    'Guest';
+
   const applyUserTheme = useCallback((user) => {
     const root = document.documentElement;
     const themeMode = user.theme_mode || 'system';
@@ -662,7 +669,7 @@ export default function Layout({ children, currentPageName: propCurrentPageName 
                   </div>
                   <div className="flex-1 min-w-0 hidden lg:block">
                     <p className="font-medium text-gray-900 dark:text-gray-100 text-sm truncate">
-                      {currentUser?.full_name || "Guest"}
+                      {resolvedUserName}
                     </p>
                     <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{currentUser?.email}</p>
                   </div>

--- a/apps/web/ethos/frontend/ethos-pages/Workspace.jsx
+++ b/apps/web/ethos/frontend/ethos-pages/Workspace.jsx
@@ -107,6 +107,12 @@ export default function Workspace() {
   const [archivedQuests, setArchivedQuests] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState("overview"); // Changed initial tab to 'overview'
+  const resolvedUserName =
+    currentUser?.full_name ||
+    currentUser?.display_name ||
+    currentUser?.username ||
+    (currentUser?.email ? currentUser.email.split('@')[0] : null) ||
+    "Your Workspace";
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -221,7 +227,7 @@ export default function Workspace() {
               </div>
               <div>
                 <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">
-                  {currentUser?.full_name || "Your Workspace"}
+                  {resolvedUserName}
                 </h1>
                 <p className="text-gray-600 dark:text-gray-300 text-sm sm:text-base">
                   {currentUser?.bio || "Manage your projects and team collaborations"}


### PR DESCRIPTION
## Summary
- attach HTTP status codes to API request errors so callers can react to specific failures
- hydrate the current user from the auth session when the legacy /api/users/me route is unavailable
- display better identity fallbacks in the layout and workspace header so authenticated users no longer appear as guests

## Testing
- npm test *(fails: Cannot find module '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_68d9e666299c832f93f8ac7dd7f0a61f