### PR TITLE
Improve Ethos frontend error handling when gateway is offline

### DIFF
--- a/apps/web/ethos/frontend/ethos-pages/Dashboard.jsx
+++ b/apps/web/ethos/frontend/ethos-pages/Dashboard.jsx
@@ -14,6 +14,8 @@ import {
 import { Link } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import { motion, AnimatePresence } from "framer-motion";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { GATEWAY_URL } from "@/api/client";
 
 import QuestCard from "../components/dashboard/QuestCard";
 import StatsOverview from "../components/dashboard/StatsOverview";
@@ -30,6 +32,7 @@ export default function Dashboard() {
   const [userQuests, setUserQuests] = useState([]);
   const [userLikesMap, setUserLikesMap] = useState(new Map());
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [filters, setFilters] = useState({
     status: "all",
@@ -40,6 +43,7 @@ export default function Dashboard() {
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
+    setLoadError(null);
     try {
       // Fetch user and basic data first
       const [me, initialGuildData] = await Promise.all([
@@ -162,6 +166,7 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error("Error loading data:", error);
+      setLoadError(error?.hint || error?.message || `Unable to contact the Ethos gateway at ${GATEWAY_URL}.`);
     }
     setIsLoading(false);
   }, []);
@@ -215,6 +220,14 @@ export default function Dashboard() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="w-full max-w-6xl mx-auto px-3 sm:px-4 md:px-6 py-4 md:py-6 space-y-4 sm:space-y-6 md:space-y-8">
+        {loadError && (
+          <Alert variant="destructive">
+            <AlertTitle>Unable to load dashboard data</AlertTitle>
+            <AlertDescription>
+              {loadError}
+            </AlertDescription>
+          </Alert>
+        )}
         {/* Header */}
         <div className="text-center py-4 sm:py-6 md:py-8">
           <h1 className="text-xl sm:text-2xl md:text-4xl font-bold text-gray-900 dark:text-white mb-2 md:mb-4">

--- a/apps/web/ethos/frontend/lib/socket.js
+++ b/apps/web/ethos/frontend/lib/socket.js
@@ -1,16 +1,45 @@
-import { io } from "socket.io-client"
+import { io } from "socket.io-client";
+
+const env = typeof process !== "undefined" ? process.env ?? {} : {};
 
 const gatewayUrl =
-  process.env.NEXT_PUBLIC_GATEWAY_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  "http://localhost:8080"
+  env.NEXT_PUBLIC_GATEWAY_URL ||
+  env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8080";
 
-const socket = typeof window !== "undefined"
-  ? io(gatewayUrl)
-  : {
-      on: () => void 0,
-      off: () => void 0,
-      emit: () => void 0,
-    }
+const isBrowser = typeof window !== "undefined";
+const shouldConnect =
+  isBrowser &&
+  (env.NEXT_PUBLIC_ENABLE_SOCKET_IO === "true" ||
+    env.NEXT_PUBLIC_ENABLE_SOCKET === "true");
 
-export default socket
+const createNoopSocket = () => ({
+  on: () => void 0,
+  off: () => void 0,
+  emit: () => void 0,
+  connect: () => void 0,
+  disconnect: () => void 0,
+});
+
+let socket = createNoopSocket();
+
+if (shouldConnect) {
+  try {
+    const client = io(gatewayUrl, { autoConnect: false });
+    client.on("connect_error", (error) => {
+      console.warn(
+        `Socket connection failed. Ensure the gateway at ${gatewayUrl} exposes a Socket.IO endpoint (set NEXT_PUBLIC_ENABLE_SOCKET_IO=false to silence this warning).`,
+        error,
+      );
+    });
+    client.connect();
+    socket = client;
+  } catch (error) {
+    console.warn("Unable to initialise Socket.IO client", error);
+    socket = createNoopSocket();
+  }
+}
+
+export const socketEnabled = shouldConnect;
+
+export default socket;


### PR DESCRIPTION
## Summary
- add a custom GatewayRequestError wrapper so API requests include actionable hints when the Ethos gateway is unavailable or missing endpoints
- surface gateway availability problems in Dashboard, QuestBoard, and the shared Layout with destructive alerts that explain how to recover
- gate the Socket.IO client behind an opt-in flag to prevent noisy 404s when the gateway does not expose the socket transport

## Testing
- npm run lint *(fails: pre-existing lint errors in the Ethos frontend project)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f4c403dc832fb1e16b9b88b59ece