### PR TITLE
Add user profile API and enable terms acceptance

### DIFF
--- a/services/ethos-gateway/Cargo.lock
+++ b/services/ethos-gateway/Cargo.lock
@@ -2874,6 +2874,8 @@ dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
  "uuid",
 ]
 

--- a/services/ethos-gateway/Cargo.toml
+++ b/services/ethos-gateway/Cargo.toml
@@ -36,7 +36,7 @@ tower-http = { version = "0.5", features = ["cors"] }
 uuid = { version = "1.7", features = ["serde", "v4", "v5"] }
 chrono = { version = "0.4", features = ["serde"] }
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
-tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
+tokio-postgres = { version = "0.7", features = ["with-uuid-1", "with-serde_json-1"] }
 dotenvy = "0.15"
 
 matrix-sdk = { version = "0.13", optional = true }

--- a/services/ethos-gateway/migrations/0003_add_user_profile_data.sql
+++ b/services/ethos-gateway/migrations/0003_add_user_profile_data.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS profile JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/services/ethos-gateway/src/migrations.rs
+++ b/services/ethos-gateway/src/migrations.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0001_create_users.sql"),
     include_str!("../migrations/0002_add_is_guest_to_users.sql"),
+    include_str!("../migrations/0003_add_user_profile_data.sql"),
 ];
 
 pub async fn run_migrations(pool: &Pool) -> anyhow::Result<()> {

--- a/services/ethos-gateway/src/routes/mod.rs
+++ b/services/ethos-gateway/src/routes/mod.rs
@@ -12,16 +12,18 @@ use crate::state::AppState;
 mod auth;
 mod conversations;
 mod stream;
+mod users;
 
 pub use auth::*;
 pub use conversations::*;
 pub use stream::*;
+pub use users::*;
 
 pub fn router(state: AppState) -> Router {
     let shared = Arc::new(state);
     let cors = CorsLayer::new()
         .allow_origin(Any)
-        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::OPTIONS])
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
 
     Router::new()
@@ -39,6 +41,7 @@ pub fn router(state: AppState) -> Router {
             get(list_messages).post(post_message),
         )
         .route("/api/conversations/:id/stream", get(stream_conversation))
+        .route("/api/users/me", get(me).put(update_me))
         .layer(cors)
         .layer(Extension(shared.clone()))
         .with_state(shared)

--- a/services/ethos-gateway/src/routes/users.rs
+++ b/services/ethos-gateway/src/routes/users.rs
@@ -1,0 +1,287 @@
+use std::{collections::HashMap, sync::Arc};
+
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use serde_json::{map::Entry, Map, Value};
+use tokio_postgres::{types::Json as PgJson, Row};
+use tracing::{error, warn};
+use uuid::Uuid;
+
+use crate::{auth::AuthSession, state::AppState};
+
+type ApiResult<T> = Result<T, (StatusCode, &'static str)>;
+
+#[derive(Debug, Serialize)]
+pub struct UserProfileResponse {
+    pub id: String,
+    pub email: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    pub is_guest: bool,
+    #[serde(flatten)]
+    pub profile: Map<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateUserRequest {
+    #[serde(default)]
+    pub display_name: Option<Option<String>>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+pub async fn me(
+    auth: AuthSession,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<UserProfileResponse>> {
+    let user_id = parse_user_id(&auth.user_id)?;
+
+    let client = state.db.get().await.map_err(|error| {
+        error!(
+            ?error,
+            "failed to acquire database connection while fetching user profile"
+        );
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to fetch user profile",
+        )
+    })?;
+
+    let row = client
+        .query_opt(
+            "SELECT id, email, display_name, is_guest, profile FROM users WHERE id = $1",
+            &[&user_id],
+        )
+        .await
+        .map_err(|error| {
+            error!(?error, "failed to fetch user profile");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to fetch user profile",
+            )
+        })?
+        .ok_or((StatusCode::NOT_FOUND, "User not found"))?;
+
+    let response = build_user_profile_response(row).map_err(|error| {
+        error!(?error, "failed to serialize user profile");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to fetch user profile",
+        )
+    })?;
+
+    Ok(Json(response))
+}
+
+pub async fn update_me(
+    auth: AuthSession,
+    State(state): State<Arc<AppState>>,
+    Json(mut payload): Json<UpdateUserRequest>,
+) -> ApiResult<Json<UserProfileResponse>> {
+    let user_id = parse_user_id(&auth.user_id)?;
+
+    let mut client = state.db.get().await.map_err(|error| {
+        error!(
+            ?error,
+            "failed to acquire database connection while updating user profile"
+        );
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to update user profile",
+        )
+    })?;
+
+    let transaction = client.transaction().await.map_err(|error| {
+        error!(
+            ?error,
+            "failed to start transaction while updating user profile"
+        );
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to update user profile",
+        )
+    })?;
+
+    let row = transaction
+        .query_opt(
+            "SELECT id, email, display_name, is_guest, profile FROM users WHERE id = $1 FOR UPDATE",
+            &[&user_id],
+        )
+        .await
+        .map_err(|error| {
+            error!(?error, "failed to fetch user profile for update");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to update user profile",
+            )
+        })?
+        .ok_or((StatusCode::NOT_FOUND, "User not found"))?;
+
+    let mut display_name: Option<String> = row.try_get("display_name").map_err(|error| {
+        error!(
+            ?error,
+            "failed to decode display_name during profile update"
+        );
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to update user profile",
+        )
+    })?;
+    let mut profile = load_profile_map(row)?;
+
+    if let Some(display_name_override) = payload.display_name.take() {
+        display_name = normalize_optional_string(display_name_override);
+    }
+
+    sanitize_reserved_keys(&mut payload.extra);
+    for (key, value) in payload.extra.into_iter() {
+        profile.insert(key, value);
+    }
+
+    let stored_profile = PgJson(Value::Object(profile.clone()));
+
+    let updated_row = transaction
+        .query_one(
+            "UPDATE users SET display_name = $2, profile = $3 WHERE id = $1 RETURNING id, email, display_name, is_guest, profile",
+            &[&user_id, &display_name, &stored_profile],
+        )
+        .await
+        .map_err(|error| {
+            error!(?error, "failed to persist user profile updates");
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update user profile")
+        })?;
+
+    transaction.commit().await.map_err(|error| {
+        error!(?error, "failed to commit user profile transaction");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to update user profile",
+        )
+    })?;
+
+    let response = build_user_profile_response(updated_row).map_err(|error| {
+        error!(?error, "failed to serialize updated user profile");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to update user profile",
+        )
+    })?;
+
+    Ok(Json(response))
+}
+
+fn parse_user_id(id: &str) -> ApiResult<Uuid> {
+    Uuid::parse_str(id).map_err(|error| {
+        warn!(?error, "received invalid user identifier");
+        (StatusCode::BAD_REQUEST, "Invalid user identifier")
+    })
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_owned())
+        }
+    })
+}
+
+fn sanitize_reserved_keys(values: &mut HashMap<String, Value>) {
+    const RESERVED: &[&str] = &["id", "email", "display_name", "is_guest", "profile"];
+    for key in RESERVED {
+        values.remove(*key);
+    }
+}
+
+fn load_profile_map(row: Row) -> ApiResult<Map<String, Value>> {
+    let profile_value: PgJson<Value> = row.try_get("profile").map_err(|error| {
+        error!(?error, "failed to decode profile column");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to update user profile",
+        )
+    })?;
+
+    let mut profile = match profile_value.0 {
+        Value::Object(map) => map,
+        Value::Null => Map::new(),
+        other => {
+            warn!(
+                ?other,
+                "unexpected non-object profile payload; resetting to empty object"
+            );
+            Map::new()
+        }
+    };
+
+    ensure_profile_defaults(&mut profile);
+
+    Ok(profile)
+}
+
+fn build_user_profile_response(row: Row) -> Result<UserProfileResponse, tokio_postgres::Error> {
+    let id: Uuid = row.try_get("id")?;
+    let email: String = row.try_get("email")?;
+    let display_name: Option<String> = row.try_get("display_name")?;
+    let is_guest: bool = row.try_get("is_guest")?;
+    let profile_value: PgJson<Value> = row.try_get("profile")?;
+
+    let mut profile = match profile_value.0 {
+        Value::Object(map) => map,
+        Value::Null => Map::new(),
+        other => {
+            warn!(
+                ?other,
+                "unexpected non-object profile payload while building response"
+            );
+            Map::new()
+        }
+    };
+
+    ensure_profile_defaults(&mut profile);
+
+    Ok(UserProfileResponse {
+        id: id.to_string(),
+        email,
+        display_name,
+        is_guest,
+        profile,
+    })
+}
+
+fn ensure_profile_defaults(profile: &mut Map<String, Value>) {
+    match profile.entry("terms_accepted".to_string()) {
+        Entry::Vacant(entry) => {
+            entry.insert(Value::Bool(false));
+        }
+        Entry::Occupied(mut entry) => {
+            if !entry.get().is_boolean() {
+                entry.insert(Value::Bool(false));
+            }
+        }
+    }
+
+    match profile.entry("tutorial_completed".to_string()) {
+        Entry::Vacant(entry) => {
+            entry.insert(Value::Bool(false));
+        }
+        Entry::Occupied(mut entry) => {
+            if !entry.get().is_boolean() {
+                entry.insert(Value::Bool(false));
+            }
+        }
+    }
+
+    match profile.entry("tutorial_progress".to_string()) {
+        Entry::Vacant(entry) => {
+            entry.insert(Value::Object(Map::new()));
+        }
+        Entry::Occupied(mut entry) => {
+            if !entry.get().is_object() {
+                entry.insert(Value::Object(Map::new()));
+            }
+        }
+    }
+}

--- a/services/ethos-gateway/tests/integration.rs
+++ b/services/ethos-gateway/tests/integration.rs
@@ -38,6 +38,7 @@ fn sign_token(config: &GatewayConfig, user_id: &str, email: &str) -> String {
         sub: user_id.to_string(),
         email: email.to_string(),
         display_name: Some("Test".into()),
+        is_guest: false,
         exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as usize,
     };
     jsonwebtoken::encode(


### PR DESCRIPTION
## Summary
- add a JSON-backed user profile column and migrate it, wiring a new /api/users/me read/write endpoint that stores terms acceptance and tutorial metadata
- expose the users route in the router, allow PUT requests through CORS, and enable serde_json support for tokio-postgres
- update the integration test token helper for the new claim fields

## Testing
- cargo test --manifest-path services/ethos-gateway/Cargo.toml *(fails: Postgres is not running in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fe5d5270832fba6957b6c9c95663